### PR TITLE
fix(card): handle signatures on any TLV block

### DIFF
--- a/internal/card/AGENTS.md
+++ b/internal/card/AGENTS.md
@@ -331,6 +331,22 @@ for i := 0; i < len(records); i++ {
 }
 ```
 
+### Handling Non-Compliant Signatures
+
+According to the regulation, unsigned EFs (ICC, IC, certificates, Card_Download) should NOT have signatures. However, some real-world card files may incorrectly include signatures on these EFs due to:
+
+- Non-compliant card personalization systems
+- Manufacturer-specific implementations
+- Legacy or regional variations
+
+**Parsing Policy (Be Liberal):**
+
+When parsing, we silently ignore signatures on unsigned EFs rather than rejecting the file. This follows the "be liberal in what you accept" principle, making the parser more robust for real-world data. The signature is not attached to the protobuf message, maintaining regulation compliance in our data model.
+
+**Marshalling Policy (Be Strict):**
+
+When marshalling, we strictly follow the regulation and never write signatures for unsigned EFs. This ensures generated files are always compliant.
+
 ## Generation-Specific Type Splitting
 
 ### Principle: Split Types by Generation for Structural Differences

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/ca_certificate.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/ca_certificate.pb.go
@@ -39,6 +39,10 @@ const (
 type CaCertificate struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_RsaCertificate *v1.RsaCertificate     `protobuf:"bytes,1,opt,name=rsa_certificate,json=rsaCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -75,8 +79,34 @@ func (x *CaCertificate) GetRsaCertificate() *v1.RsaCertificate {
 	return nil
 }
 
+func (x *CaCertificate) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *CaCertificate) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *CaCertificate) SetRsaCertificate(v *v1.RsaCertificate) {
 	x.xxx_hidden_RsaCertificate = v
+}
+
+func (x *CaCertificate) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *CaCertificate) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *CaCertificate) HasRsaCertificate() bool {
@@ -86,8 +116,31 @@ func (x *CaCertificate) HasRsaCertificate() bool {
 	return x.xxx_hidden_RsaCertificate != nil
 }
 
+func (x *CaCertificate) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *CaCertificate) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *CaCertificate) ClearRsaCertificate() {
 	x.xxx_hidden_RsaCertificate = nil
+}
+
+func (x *CaCertificate) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *CaCertificate) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type CaCertificate_builder struct {
@@ -95,6 +148,15 @@ type CaCertificate_builder struct {
 
 	// RSA certificate containing the Member State CA's public key.
 	RsaCertificate *v1.RsaCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen1):
+	//
+	//	Signature ::= OCTET STRING (SIZE(128))
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 CaCertificate_builder) Build() *CaCertificate {
@@ -102,6 +164,11 @@ func (b0 CaCertificate_builder) Build() *CaCertificate {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_RsaCertificate = b.RsaCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -109,23 +176,27 @@ var File_wayplatform_connect_tachograph_card_v1_ca_certificate_proto protoreflec
 
 const file_wayplatform_connect_tachograph_card_v1_ca_certificate_proto_rawDesc = "" +
 	"\n" +
-	";wayplatform/connect/tachograph/card/v1/ca_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/rsa_certificate.proto\"t\n" +
+	";wayplatform/connect/tachograph/card/v1/ca_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/rsa_certificate.proto\"\xf6\x01\n" +
 	"\rCaCertificate\x12c\n" +
-	"\x0frsa_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.RsaCertificateR\x0ersaCertificateB\xdf\x02\n" +
+	"\x0frsa_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.RsaCertificateR\x0ersaCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xdf\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x12CaCertificateProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_proto_goTypes = []any{
 	(*CaCertificate)(nil),     // 0: wayplatform.connect.tachograph.card.v1.CaCertificate
 	(*v1.RsaCertificate)(nil), // 1: wayplatform.connect.tachograph.security.v1.RsaCertificate
+	(*v1.Authentication)(nil), // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.CaCertificate.rsa_certificate:type_name -> wayplatform.connect.tachograph.security.v1.RsaCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.CaCertificate.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_ca_certificate_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/ca_certificate_g2.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/ca_certificate_g2.pb.go
@@ -36,6 +36,10 @@ const (
 type CaCertificateG2 struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_EccCertificate *v1.EccCertificate     `protobuf:"bytes,1,opt,name=ecc_certificate,json=eccCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -72,8 +76,34 @@ func (x *CaCertificateG2) GetEccCertificate() *v1.EccCertificate {
 	return nil
 }
 
+func (x *CaCertificateG2) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *CaCertificateG2) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *CaCertificateG2) SetEccCertificate(v *v1.EccCertificate) {
 	x.xxx_hidden_EccCertificate = v
+}
+
+func (x *CaCertificateG2) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *CaCertificateG2) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *CaCertificateG2) HasEccCertificate() bool {
@@ -83,8 +113,31 @@ func (x *CaCertificateG2) HasEccCertificate() bool {
 	return x.xxx_hidden_EccCertificate != nil
 }
 
+func (x *CaCertificateG2) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *CaCertificateG2) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *CaCertificateG2) ClearEccCertificate() {
 	x.xxx_hidden_EccCertificate = nil
+}
+
+func (x *CaCertificateG2) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *CaCertificateG2) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type CaCertificateG2_builder struct {
@@ -92,6 +145,15 @@ type CaCertificateG2_builder struct {
 
 	// ECC certificate containing the Member State CA's public key.
 	EccCertificate *v1.EccCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 CaCertificateG2_builder) Build() *CaCertificateG2 {
@@ -99,6 +161,11 @@ func (b0 CaCertificateG2_builder) Build() *CaCertificateG2 {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_EccCertificate = b.EccCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -106,23 +173,27 @@ var File_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto protoref
 
 const file_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto_rawDesc = "" +
 	"\n" +
-	">wayplatform/connect/tachograph/card/v1/ca_certificate_g2.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"v\n" +
+	">wayplatform/connect/tachograph/card/v1/ca_certificate_g2.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"\xf8\x01\n" +
 	"\x0fCaCertificateG2\x12c\n" +
-	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificateB\xe1\x02\n" +
+	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe1\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x14CaCertificateG2ProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto_goTypes = []any{
 	(*CaCertificateG2)(nil),   // 0: wayplatform.connect.tachograph.card.v1.CaCertificateG2
 	(*v1.EccCertificate)(nil), // 1: wayplatform.connect.tachograph.security.v1.EccCertificate
+	(*v1.Authentication)(nil), // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.CaCertificateG2.ecc_certificate:type_name -> wayplatform.connect.tachograph.security.v1.EccCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.CaCertificateG2.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_ca_certificate_g2_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_certificate.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_certificate.pb.go
@@ -37,6 +37,10 @@ const (
 type CardCertificate struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_RsaCertificate *v1.RsaCertificate     `protobuf:"bytes,1,opt,name=rsa_certificate,json=rsaCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -73,8 +77,34 @@ func (x *CardCertificate) GetRsaCertificate() *v1.RsaCertificate {
 	return nil
 }
 
+func (x *CardCertificate) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *CardCertificate) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *CardCertificate) SetRsaCertificate(v *v1.RsaCertificate) {
 	x.xxx_hidden_RsaCertificate = v
+}
+
+func (x *CardCertificate) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *CardCertificate) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *CardCertificate) HasRsaCertificate() bool {
@@ -84,8 +114,31 @@ func (x *CardCertificate) HasRsaCertificate() bool {
 	return x.xxx_hidden_RsaCertificate != nil
 }
 
+func (x *CardCertificate) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *CardCertificate) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *CardCertificate) ClearRsaCertificate() {
 	x.xxx_hidden_RsaCertificate = nil
+}
+
+func (x *CardCertificate) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *CardCertificate) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type CardCertificate_builder struct {
@@ -93,6 +146,15 @@ type CardCertificate_builder struct {
 
 	// RSA certificate containing the card's public key for authentication.
 	RsaCertificate *v1.RsaCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen1):
+	//
+	//	Signature ::= OCTET STRING (SIZE(128))
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 CardCertificate_builder) Build() *CardCertificate {
@@ -100,6 +162,11 @@ func (b0 CardCertificate_builder) Build() *CardCertificate {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_RsaCertificate = b.RsaCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -107,23 +174,27 @@ var File_wayplatform_connect_tachograph_card_v1_card_certificate_proto protorefl
 
 const file_wayplatform_connect_tachograph_card_v1_card_certificate_proto_rawDesc = "" +
 	"\n" +
-	"=wayplatform/connect/tachograph/card/v1/card_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/rsa_certificate.proto\"v\n" +
+	"=wayplatform/connect/tachograph/card/v1/card_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/rsa_certificate.proto\"\xf8\x01\n" +
 	"\x0fCardCertificate\x12c\n" +
-	"\x0frsa_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.RsaCertificateR\x0ersaCertificateB\xe1\x02\n" +
+	"\x0frsa_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.RsaCertificateR\x0ersaCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe1\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x14CardCertificateProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_card_certificate_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_card_certificate_proto_goTypes = []any{
 	(*CardCertificate)(nil),   // 0: wayplatform.connect.tachograph.card.v1.CardCertificate
 	(*v1.RsaCertificate)(nil), // 1: wayplatform.connect.tachograph.security.v1.RsaCertificate
+	(*v1.Authentication)(nil), // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_card_certificate_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.CardCertificate.rsa_certificate:type_name -> wayplatform.connect.tachograph.security.v1.RsaCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.CardCertificate.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_card_certificate_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_download_driver.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_download_driver.pb.go
@@ -151,10 +151,7 @@ type CardDownloadDriver_builder struct {
 	//
 	//	TimeReal ::= INTEGER (0..2^32-1)
 	Timestamp *timestamppb.Timestamp
-	// Signature data from the following file block, if tagged as a signature for
-	// this EF according to the card file format specification (Appendix 2).
-	//
-	// See Data Dictionary, Section 2.149, `Signature`.
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
 	//
 	// ASN.1 Definition (Gen1):
 	//
@@ -163,11 +160,6 @@ type CardDownloadDriver_builder struct {
 	// ASN.1 Definition (Gen2):
 	//
 	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
-	//
-	// Gen2 uses ECDSA signatures with variable lengths based on the curve:
-	// - 256-bit curves: ~64 bytes
-	// - 384-bit curves: ~96 bytes
-	// - 512/521-bit curves: ~128-132 bytes
 	Signature []byte
 	// Result of cryptographic signature authentication for this Elementary File.
 	// Present when signature verification has been performed.

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_ma_certificate.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_ma_certificate.pb.go
@@ -38,6 +38,10 @@ const (
 type CardMaCertificate struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_EccCertificate *v1.EccCertificate     `protobuf:"bytes,1,opt,name=ecc_certificate,json=eccCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -74,8 +78,34 @@ func (x *CardMaCertificate) GetEccCertificate() *v1.EccCertificate {
 	return nil
 }
 
+func (x *CardMaCertificate) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *CardMaCertificate) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *CardMaCertificate) SetEccCertificate(v *v1.EccCertificate) {
 	x.xxx_hidden_EccCertificate = v
+}
+
+func (x *CardMaCertificate) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *CardMaCertificate) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *CardMaCertificate) HasEccCertificate() bool {
@@ -85,8 +115,31 @@ func (x *CardMaCertificate) HasEccCertificate() bool {
 	return x.xxx_hidden_EccCertificate != nil
 }
 
+func (x *CardMaCertificate) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *CardMaCertificate) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *CardMaCertificate) ClearEccCertificate() {
 	x.xxx_hidden_EccCertificate = nil
+}
+
+func (x *CardMaCertificate) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *CardMaCertificate) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type CardMaCertificate_builder struct {
@@ -94,6 +147,15 @@ type CardMaCertificate_builder struct {
 
 	// ECC certificate containing the card's public key for mutual authentication.
 	EccCertificate *v1.EccCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 CardMaCertificate_builder) Build() *CardMaCertificate {
@@ -101,6 +163,11 @@ func (b0 CardMaCertificate_builder) Build() *CardMaCertificate {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_EccCertificate = b.EccCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -108,23 +175,27 @@ var File_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto protor
 
 const file_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto_rawDesc = "" +
 	"\n" +
-	"@wayplatform/connect/tachograph/card/v1/card_ma_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"x\n" +
+	"@wayplatform/connect/tachograph/card/v1/card_ma_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"\xfa\x01\n" +
 	"\x11CardMaCertificate\x12c\n" +
-	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificateB\xe3\x02\n" +
+	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe3\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x16CardMaCertificateProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto_goTypes = []any{
 	(*CardMaCertificate)(nil), // 0: wayplatform.connect.tachograph.card.v1.CardMaCertificate
 	(*v1.EccCertificate)(nil), // 1: wayplatform.connect.tachograph.security.v1.EccCertificate
+	(*v1.Authentication)(nil), // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.CardMaCertificate.ecc_certificate:type_name -> wayplatform.connect.tachograph.security.v1.EccCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.CardMaCertificate.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_card_ma_certificate_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_sign_certificate.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/card_sign_certificate.pb.go
@@ -40,6 +40,10 @@ const (
 type CardSignCertificate struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_EccCertificate *v1.EccCertificate     `protobuf:"bytes,1,opt,name=ecc_certificate,json=eccCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -76,8 +80,34 @@ func (x *CardSignCertificate) GetEccCertificate() *v1.EccCertificate {
 	return nil
 }
 
+func (x *CardSignCertificate) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *CardSignCertificate) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *CardSignCertificate) SetEccCertificate(v *v1.EccCertificate) {
 	x.xxx_hidden_EccCertificate = v
+}
+
+func (x *CardSignCertificate) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *CardSignCertificate) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *CardSignCertificate) HasEccCertificate() bool {
@@ -87,8 +117,31 @@ func (x *CardSignCertificate) HasEccCertificate() bool {
 	return x.xxx_hidden_EccCertificate != nil
 }
 
+func (x *CardSignCertificate) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *CardSignCertificate) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *CardSignCertificate) ClearEccCertificate() {
 	x.xxx_hidden_EccCertificate = nil
+}
+
+func (x *CardSignCertificate) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *CardSignCertificate) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type CardSignCertificate_builder struct {
@@ -96,6 +149,15 @@ type CardSignCertificate_builder struct {
 
 	// ECC certificate containing the card's public key for digital signatures.
 	EccCertificate *v1.EccCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 CardSignCertificate_builder) Build() *CardSignCertificate {
@@ -103,6 +165,11 @@ func (b0 CardSignCertificate_builder) Build() *CardSignCertificate {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_EccCertificate = b.EccCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -110,23 +177,27 @@ var File_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto prot
 
 const file_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto_rawDesc = "" +
 	"\n" +
-	"Bwayplatform/connect/tachograph/card/v1/card_sign_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"z\n" +
+	"Bwayplatform/connect/tachograph/card/v1/card_sign_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"\xfc\x01\n" +
 	"\x13CardSignCertificate\x12c\n" +
-	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificateB\xe5\x02\n" +
+	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe5\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x18CardSignCertificateProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto_goTypes = []any{
 	(*CardSignCertificate)(nil), // 0: wayplatform.connect.tachograph.card.v1.CardSignCertificate
 	(*v1.EccCertificate)(nil),   // 1: wayplatform.connect.tachograph.security.v1.EccCertificate
+	(*v1.Authentication)(nil),   // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.CardSignCertificate.ecc_certificate:type_name -> wayplatform.connect.tachograph.security.v1.EccCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.CardSignCertificate.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_card_sign_certificate_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/ic.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/ic.pb.go
@@ -7,6 +7,7 @@
 package cardv1
 
 import (
+	v1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/security/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -40,6 +41,8 @@ type Ic struct {
 	state                                protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_IcSerialNumber            []byte                 `protobuf:"bytes,1,opt,name=ic_serial_number,json=icSerialNumber"`
 	xxx_hidden_IcManufacturingReferences []byte                 `protobuf:"bytes,2,opt,name=ic_manufacturing_references,json=icManufacturingReferences"`
+	xxx_hidden_Signature                 []byte                 `protobuf:"bytes,3,opt,name=signature"`
+	xxx_hidden_Authentication            *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
 	XXX_raceDetectHookData               protoimpl.RaceDetectHookData
 	XXX_presence                         [1]uint32
 	unknownFields                        protoimpl.UnknownFields
@@ -85,12 +88,26 @@ func (x *Ic) GetIcManufacturingReferences() []byte {
 	return nil
 }
 
+func (x *Ic) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *Ic) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *Ic) SetIcSerialNumber(v []byte) {
 	if v == nil {
 		v = []byte{}
 	}
 	x.xxx_hidden_IcSerialNumber = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 2)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 4)
 }
 
 func (x *Ic) SetIcManufacturingReferences(v []byte) {
@@ -98,7 +115,19 @@ func (x *Ic) SetIcManufacturingReferences(v []byte) {
 		v = []byte{}
 	}
 	x.xxx_hidden_IcManufacturingReferences = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 2)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 4)
+}
+
+func (x *Ic) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 4)
+}
+
+func (x *Ic) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *Ic) HasIcSerialNumber() bool {
@@ -115,6 +144,20 @@ func (x *Ic) HasIcManufacturingReferences() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
 }
 
+func (x *Ic) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+}
+
+func (x *Ic) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *Ic) ClearIcSerialNumber() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
 	x.xxx_hidden_IcSerialNumber = nil
@@ -123,6 +166,15 @@ func (x *Ic) ClearIcSerialNumber() {
 func (x *Ic) ClearIcManufacturingReferences() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
 	x.xxx_hidden_IcManufacturingReferences = nil
+}
+
+func (x *Ic) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *Ic) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type Ic_builder struct {
@@ -146,6 +198,19 @@ type Ic_builder struct {
 	//
 	//	OCTET STRING (SIZE(4))
 	IcManufacturingReferences []byte
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen1):
+	//
+	//	Signature ::= OCTET STRING (SIZE(128))
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 Ic_builder) Build() *Ic {
@@ -153,13 +218,18 @@ func (b0 Ic_builder) Build() *Ic {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.IcSerialNumber != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 2)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 4)
 		x.xxx_hidden_IcSerialNumber = b.IcSerialNumber
 	}
 	if b.IcManufacturingReferences != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 2)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 4)
 		x.xxx_hidden_IcManufacturingReferences = b.IcManufacturingReferences
 	}
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 4)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -167,22 +237,26 @@ var File_wayplatform_connect_tachograph_card_v1_ic_proto protoreflect.FileDescri
 
 const file_wayplatform_connect_tachograph_card_v1_ic_proto_rawDesc = "" +
 	"\n" +
-	"/wayplatform/connect/tachograph/card/v1/ic.proto\x12&wayplatform.connect.tachograph.card.v1\"n\n" +
+	"/wayplatform/connect/tachograph/card/v1/ic.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xf0\x01\n" +
 	"\x02Ic\x12(\n" +
 	"\x10ic_serial_number\x18\x01 \x01(\fR\x0eicSerialNumber\x12>\n" +
-	"\x1bic_manufacturing_references\x18\x02 \x01(\fR\x19icManufacturingReferencesB\xd4\x02\n" +
+	"\x1bic_manufacturing_references\x18\x02 \x01(\fR\x19icManufacturingReferences\x12\x1c\n" +
+	"\tsignature\x18\x03 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xd4\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\aIcProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_ic_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_ic_proto_goTypes = []any{
-	(*Ic)(nil), // 0: wayplatform.connect.tachograph.card.v1.Ic
+	(*Ic)(nil),                // 0: wayplatform.connect.tachograph.card.v1.Ic
+	(*v1.Authentication)(nil), // 1: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_ic_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: wayplatform.connect.tachograph.card.v1.Ic.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_ic_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/icc.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/icc.pb.go
@@ -8,6 +8,7 @@ package cardv1
 
 import (
 	v1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+	v11 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/security/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -49,6 +50,8 @@ type Icc struct {
 	xxx_hidden_CardPersonaliserId       int32                      `protobuf:"varint,4,opt,name=card_personaliser_id,json=cardPersonaliserId"`
 	xxx_hidden_EmbedderIcAssemblerId    *Icc_EmbedderIcAssemblerId `protobuf:"bytes,5,opt,name=embedder_ic_assembler_id,json=embedderIcAssemblerId"`
 	xxx_hidden_IcIdentifier             []byte                     `protobuf:"bytes,6,opt,name=ic_identifier,json=icIdentifier"`
+	xxx_hidden_Signature                []byte                     `protobuf:"bytes,7,opt,name=signature"`
+	xxx_hidden_Authentication           *v11.Authentication        `protobuf:"bytes,99,opt,name=authentication"`
 	XXX_raceDetectHookData              protoimpl.RaceDetectHookData
 	XXX_presence                        [1]uint32
 	unknownFields                       protoimpl.UnknownFields
@@ -124,9 +127,23 @@ func (x *Icc) GetIcIdentifier() []byte {
 	return nil
 }
 
+func (x *Icc) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *Icc) GetAuthentication() *v11.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *Icc) SetClockStop(v v1.ClockStopMode) {
 	x.xxx_hidden_ClockStop = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 8)
 }
 
 func (x *Icc) SetCardExtendedSerialNumber(v *v1.ExtendedSerialNumber) {
@@ -139,7 +156,7 @@ func (x *Icc) SetCardApprovalNumber(v *v1.Ia5StringValue) {
 
 func (x *Icc) SetCardPersonaliserId(v int32) {
 	x.xxx_hidden_CardPersonaliserId = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 8)
 }
 
 func (x *Icc) SetEmbedderIcAssemblerId(v *Icc_EmbedderIcAssemblerId) {
@@ -151,7 +168,19 @@ func (x *Icc) SetIcIdentifier(v []byte) {
 		v = []byte{}
 	}
 	x.xxx_hidden_IcIdentifier = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 6)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 8)
+}
+
+func (x *Icc) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 6, 8)
+}
+
+func (x *Icc) SetAuthentication(v *v11.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *Icc) HasClockStop() bool {
@@ -196,6 +225,20 @@ func (x *Icc) HasIcIdentifier() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
+func (x *Icc) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 6)
+}
+
+func (x *Icc) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *Icc) ClearClockStop() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
 	x.xxx_hidden_ClockStop = v1.ClockStopMode_CLOCK_STOP_MODE_UNSPECIFIED
@@ -221,6 +264,15 @@ func (x *Icc) ClearEmbedderIcAssemblerId() {
 func (x *Icc) ClearIcIdentifier() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
 	x.xxx_hidden_IcIdentifier = nil
+}
+
+func (x *Icc) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 6)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *Icc) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type Icc_builder struct {
@@ -262,6 +314,19 @@ type Icc_builder struct {
 	//
 	//	OCTET STRING (SIZE(2))
 	IcIdentifier []byte
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen1):
+	//
+	//	Signature ::= OCTET STRING (SIZE(128))
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v11.Authentication
 }
 
 func (b0 Icc_builder) Build() *Icc {
@@ -269,20 +334,25 @@ func (b0 Icc_builder) Build() *Icc {
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.ClockStop != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 8)
 		x.xxx_hidden_ClockStop = *b.ClockStop
 	}
 	x.xxx_hidden_CardExtendedSerialNumber = b.CardExtendedSerialNumber
 	x.xxx_hidden_CardApprovalNumber = b.CardApprovalNumber
 	if b.CardPersonaliserId != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 8)
 		x.xxx_hidden_CardPersonaliserId = *b.CardPersonaliserId
 	}
 	x.xxx_hidden_EmbedderIcAssemblerId = b.EmbedderIcAssemblerId
 	if b.IcIdentifier != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 6)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 8)
 		x.xxx_hidden_IcIdentifier = b.IcIdentifier
 	}
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 6, 8)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -444,7 +514,7 @@ var File_wayplatform_connect_tachograph_card_v1_icc_proto protoreflect.FileDescr
 
 const file_wayplatform_connect_tachograph_card_v1_icc_proto_rawDesc = "" +
 	"\n" +
-	"0wayplatform/connect/tachograph/card/v1/icc.proto\x12&wayplatform.connect.tachograph.card.v1\x1a:wayplatform/connect/tachograph/dd/v1/clock_stop_mode.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\"\x9c\x06\n" +
+	"0wayplatform/connect/tachograph/card/v1/icc.proto\x12&wayplatform.connect.tachograph.card.v1\x1a:wayplatform/connect/tachograph/dd/v1/clock_stop_mode.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\x9e\a\n" +
 	"\x03Icc\x12R\n" +
 	"\n" +
 	"clock_stop\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.ClockStopModeR\tclockStop\x12y\n" +
@@ -452,7 +522,9 @@ const file_wayplatform_connect_tachograph_card_v1_icc_proto_rawDesc = "" +
 	"\x14card_approval_number\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x12cardApprovalNumber\x120\n" +
 	"\x14card_personaliser_id\x18\x04 \x01(\x05R\x12cardPersonaliserId\x12z\n" +
 	"\x18embedder_ic_assembler_id\x18\x05 \x01(\v2A.wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerIdR\x15embedderIcAssemblerId\x12#\n" +
-	"\ric_identifier\x18\x06 \x01(\fR\ficIdentifier\x1a\x8a\x02\n" +
+	"\ric_identifier\x18\x06 \x01(\fR\ficIdentifier\x12\x1c\n" +
+	"\tsignature\x18\a \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthentication\x1a\x8a\x02\n" +
 	"\x15EmbedderIcAssemblerId\x12W\n" +
 	"\fcountry_code\x18\x01 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\vcountryCode\x12]\n" +
 	"\x0fmodule_embedder\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x0emoduleEmbedder\x129\n" +
@@ -466,19 +538,21 @@ var file_wayplatform_connect_tachograph_card_v1_icc_proto_goTypes = []any{
 	(v1.ClockStopMode)(0),             // 2: wayplatform.connect.tachograph.dd.v1.ClockStopMode
 	(*v1.ExtendedSerialNumber)(nil),   // 3: wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
 	(*v1.Ia5StringValue)(nil),         // 4: wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	(*v11.Authentication)(nil),        // 5: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_icc_proto_depIdxs = []int32{
 	2, // 0: wayplatform.connect.tachograph.card.v1.Icc.clock_stop:type_name -> wayplatform.connect.tachograph.dd.v1.ClockStopMode
 	3, // 1: wayplatform.connect.tachograph.card.v1.Icc.card_extended_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
 	4, // 2: wayplatform.connect.tachograph.card.v1.Icc.card_approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
 	1, // 3: wayplatform.connect.tachograph.card.v1.Icc.embedder_ic_assembler_id:type_name -> wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerId
-	4, // 4: wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerId.country_code:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	4, // 5: wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerId.module_embedder:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	5, // 4: wayplatform.connect.tachograph.card.v1.Icc.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	4, // 5: wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerId.country_code:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	4, // 6: wayplatform.connect.tachograph.card.v1.Icc.EmbedderIcAssemblerId.module_embedder:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_icc_proto_init() }

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/link_certificate.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/link_certificate.pb.go
@@ -44,6 +44,10 @@ const (
 type LinkCertificate struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_EccCertificate *v1.EccCertificate     `protobuf:"bytes,1,opt,name=ecc_certificate,json=eccCertificate"`
+	xxx_hidden_Signature      []byte                 `protobuf:"bytes,2,opt,name=signature"`
+	xxx_hidden_Authentication *v1.Authentication     `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -80,8 +84,34 @@ func (x *LinkCertificate) GetEccCertificate() *v1.EccCertificate {
 	return nil
 }
 
+func (x *LinkCertificate) GetSignature() []byte {
+	if x != nil {
+		return x.xxx_hidden_Signature
+	}
+	return nil
+}
+
+func (x *LinkCertificate) GetAuthentication() *v1.Authentication {
+	if x != nil {
+		return x.xxx_hidden_Authentication
+	}
+	return nil
+}
+
 func (x *LinkCertificate) SetEccCertificate(v *v1.EccCertificate) {
 	x.xxx_hidden_EccCertificate = v
+}
+
+func (x *LinkCertificate) SetSignature(v []byte) {
+	if v == nil {
+		v = []byte{}
+	}
+	x.xxx_hidden_Signature = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *LinkCertificate) SetAuthentication(v *v1.Authentication) {
+	x.xxx_hidden_Authentication = v
 }
 
 func (x *LinkCertificate) HasEccCertificate() bool {
@@ -91,8 +121,31 @@ func (x *LinkCertificate) HasEccCertificate() bool {
 	return x.xxx_hidden_EccCertificate != nil
 }
 
+func (x *LinkCertificate) HasSignature() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *LinkCertificate) HasAuthentication() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Authentication != nil
+}
+
 func (x *LinkCertificate) ClearEccCertificate() {
 	x.xxx_hidden_EccCertificate = nil
+}
+
+func (x *LinkCertificate) ClearSignature() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Signature = nil
+}
+
+func (x *LinkCertificate) ClearAuthentication() {
+	x.xxx_hidden_Authentication = nil
 }
 
 type LinkCertificate_builder struct {
@@ -100,6 +153,15 @@ type LinkCertificate_builder struct {
 
 	// ECC certificate for linking old and new ERCA root certificates.
 	EccCertificate *v1.EccCertificate
+	// Signature (non-compliant per Section 3.3, captured for data fidelity).
+	//
+	// ASN.1 Definition (Gen2):
+	//
+	//	Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+	Signature []byte
+	// Result of cryptographic signature authentication for this Elementary File.
+	// Present when signature verification has been performed.
+	Authentication *v1.Authentication
 }
 
 func (b0 LinkCertificate_builder) Build() *LinkCertificate {
@@ -107,6 +169,11 @@ func (b0 LinkCertificate_builder) Build() *LinkCertificate {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_EccCertificate = b.EccCertificate
+	if b.Signature != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Signature = b.Signature
+	}
+	x.xxx_hidden_Authentication = b.Authentication
 	return m0
 }
 
@@ -114,23 +181,27 @@ var File_wayplatform_connect_tachograph_card_v1_link_certificate_proto protorefl
 
 const file_wayplatform_connect_tachograph_card_v1_link_certificate_proto_rawDesc = "" +
 	"\n" +
-	"=wayplatform/connect/tachograph/card/v1/link_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"v\n" +
+	"=wayplatform/connect/tachograph/card/v1/link_certificate.proto\x12&wayplatform.connect.tachograph.card.v1\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\x1a@wayplatform/connect/tachograph/security/v1/ecc_certificate.proto\"\xf8\x01\n" +
 	"\x0fLinkCertificate\x12c\n" +
-	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificateB\xe1\x02\n" +
+	"\x0fecc_certificate\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.security.v1.EccCertificateR\x0eeccCertificate\x12\x1c\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x12b\n" +
+	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe1\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x14LinkCertificateProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_card_v1_link_certificate_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_wayplatform_connect_tachograph_card_v1_link_certificate_proto_goTypes = []any{
 	(*LinkCertificate)(nil),   // 0: wayplatform.connect.tachograph.card.v1.LinkCertificate
 	(*v1.EccCertificate)(nil), // 1: wayplatform.connect.tachograph.security.v1.EccCertificate
+	(*v1.Authentication)(nil), // 2: wayplatform.connect.tachograph.security.v1.Authentication
 }
 var file_wayplatform_connect_tachograph_card_v1_link_certificate_proto_depIdxs = []int32{
 	1, // 0: wayplatform.connect.tachograph.card.v1.LinkCertificate.ecc_certificate:type_name -> wayplatform.connect.tachograph.security.v1.EccCertificate
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: wayplatform.connect.tachograph.card.v1.LinkCertificate.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_card_v1_link_certificate_proto_init() }

--- a/proto/wayplatform/connect/tachograph/card/v1/ca_certificate.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/ca_certificate.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/rsa_certificate.proto";
 
 // Data from EF CA_Certificate (File ID 'C108h') for Generation 1 cards.
@@ -22,4 +23,15 @@ import "wayplatform/connect/tachograph/security/v1/rsa_certificate.proto";
 message CaCertificate {
   // RSA certificate containing the Member State CA's public key.
   security.v1.RsaCertificate rsa_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen1):
+  //
+  //     Signature ::= OCTET STRING (SIZE(128))
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/ca_certificate_g2.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/ca_certificate_g2.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 
 // CaCertificateG2 holds data from EF CA_Certificate (FID 'C108h').
@@ -19,5 +20,16 @@ import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 message CaCertificateG2 {
   // ECC certificate containing the Member State CA's public key.
   security.v1.EccCertificate ecc_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }
 

--- a/proto/wayplatform/connect/tachograph/card/v1/card_certificate.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/card_certificate.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/rsa_certificate.proto";
 
 // Data from EF Card_Certificate (File ID 'C100h').
@@ -20,4 +21,15 @@ import "wayplatform/connect/tachograph/security/v1/rsa_certificate.proto";
 message CardCertificate {
   // RSA certificate containing the card's public key for authentication.
   security.v1.RsaCertificate rsa_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen1):
+  //
+  //     Signature ::= OCTET STRING (SIZE(128))
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/card_download_driver.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/card_download_driver.proto
@@ -27,10 +27,7 @@ message CardDownloadDriver {
   //     TimeReal ::= INTEGER (0..2^32-1)
   google.protobuf.Timestamp timestamp = 1;
 
-  // Signature data from the following file block, if tagged as a signature for
-  // this EF according to the card file format specification (Appendix 2).
-  //
-  // See Data Dictionary, Section 2.149, `Signature`.
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
   //
   // ASN.1 Definition (Gen1):
   //
@@ -39,11 +36,6 @@ message CardDownloadDriver {
   // ASN.1 Definition (Gen2):
   //
   //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
-  //
-  // Gen2 uses ECDSA signatures with variable lengths based on the curve:
-  // - 256-bit curves: ~64 bytes
-  // - 384-bit curves: ~96 bytes
-  // - 512/521-bit curves: ~128-132 bytes
   bytes signature = 2;
 
   // Result of cryptographic signature authentication for this Elementary File.

--- a/proto/wayplatform/connect/tachograph/card/v1/card_ma_certificate.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/card_ma_certificate.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 
 // Data from EF CardMA_Certificate (File ID 'C100h').
@@ -21,4 +22,15 @@ import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 message CardMaCertificate {
   // ECC certificate containing the card's public key for mutual authentication.
   security.v1.EccCertificate ecc_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/card_sign_certificate.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/card_sign_certificate.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 
 // Data from EF CardSignCertificate (File ID 'C101h').
@@ -23,4 +24,15 @@ import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 message CardSignCertificate {
   // ECC certificate containing the card's public key for digital signatures.
   security.v1.EccCertificate ecc_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/ic.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/ic.proto
@@ -2,6 +2,8 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
+
 // Represents the content of the EF_IC file, which contains identification data
 // for the integrated circuit chip.
 //
@@ -38,4 +40,19 @@ message Ic {
   //
   //     OCTET STRING (SIZE(4))
   bytes ic_manufacturing_references = 2;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen1):
+  //
+  //     Signature ::= OCTET STRING (SIZE(128))
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 3;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/icc.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/icc.proto
@@ -5,6 +5,7 @@ package wayplatform.connect.tachograph.card.v1;
 import "wayplatform/connect/tachograph/dd/v1/clock_stop_mode.proto";
 import "wayplatform/connect/tachograph/dd/v1/extended_serial_number.proto";
 import "wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto";
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 
 // Represents the content of the EF_ICC file, which contains identification data
 // for the Integrated Circuit Card.
@@ -105,4 +106,19 @@ message Icc {
   //
   //     OCTET STRING (SIZE(2))
   bytes ic_identifier = 6;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen1):
+  //
+  //     Signature ::= OCTET STRING (SIZE(128))
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 7;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }

--- a/proto/wayplatform/connect/tachograph/card/v1/link_certificate.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/link_certificate.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package wayplatform.connect.tachograph.card.v1;
 
+import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 
 // Data from EF Link_Certificate (File ID 'C109h').
@@ -27,4 +28,15 @@ import "wayplatform/connect/tachograph/security/v1/ecc_certificate.proto";
 message LinkCertificate {
   // ECC certificate for linking old and new ERCA root certificates.
   security.v1.EccCertificate ecc_certificate = 1;
+
+  // Signature (non-compliant per Section 3.3, captured for data fidelity).
+  //
+  // ASN.1 Definition (Gen2):
+  //
+  //     Signature ::= OCTET STRING (variable size, depends on elliptic curve)
+  bytes signature = 2;
+
+  // Result of cryptographic signature authentication for this Elementary File.
+  // Present when signature verification has been performed.
+  tachograph.security.v1.Authentication authentication = 99;
 }


### PR DESCRIPTION
Regardless if the spec allows a signature or not, it's better we capture
it than to throw an error.

Fixes #6
