### PR TITLE
fix(card): derive cyclic activity max records from buffer size

### DIFF
--- a/internal/card/activity.go
+++ b/internal/card/activity.go
@@ -285,12 +285,21 @@ func NewCyclicRecordIterator(buffer []byte, startPos int) *cyclicRecordIterator 
 // Returns true if a record was found, false if end of chain or error.
 // The iterator traverses backwards from newest to oldest record.
 func (it *cyclicRecordIterator) Next() bool {
-	const maxRecords = 366 // Safety limit to prevent infinite loops (max days per year + 1)
+	// Safety limit derived from buffer size: the buffer cannot contain more records
+	// than buffer_size / min_record_size. The iterator rejects records with length < 4
+	// (below), so 4 bytes is the absolute minimum per record. This catches infinite
+	// loops from corrupted linked-list pointers while accepting any valid card,
+	// including cards with >366 daily records (observed on a real Gen1 card with
+	// activityStructureLength=13776 containing 379 daily records).
+	maxRecords := len(it.buffer) / 4
+	if maxRecords == 0 {
+		maxRecords = 1
+	}
 	if it.err != nil {
 		return false
 	}
 	if it.recordCount >= maxRecords {
-		it.err = fmt.Errorf("exceeded maximum record count (%d), possible infinite loop", maxRecords)
+		it.err = fmt.Errorf("exceeded maximum record count (%d for %d-byte buffer), possible infinite loop", maxRecords, len(it.buffer))
 		return false
 	}
 	if len(it.buffer) == 0 {


### PR DESCRIPTION
## Summary

- Replace hardcoded `maxRecords = 366` safety limit in `cyclicRecordIterator.Next()` with a limit derived from the actual buffer size: `len(buffer) / 4`
- Fixes valid driver cards failing with "exceeded maximum record count (366), possible infinite loop"
- Observed on a real Norwegian Gen1 card with 379 daily activity records in a 13,776-byte buffer

## Context

The old limit assumed at most 365+1 daily records, but cards with many short activity days can exceed this within their cyclic buffer. The new limit (`buffer_size / 4`) is the theoretical upper bound since the iterator already rejects records with `currentRecordLength < 4`. This still catches infinite loops from corrupted linked-list pointers while never rejecting valid data.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Verified the Norwegian Gen1 card (379 records) parses successfully with the patched limit

Note:
This is the same issue that @Zuziss experienced.

Closes #11 