### PR TITLE
fix(vu): correct Gen2 V2 parsing for VRN, calibration records, and string encoding

### DIFF
--- a/internal/dd/encoding.go
+++ b/internal/dd/encoding.go
@@ -87,17 +87,18 @@ func getCodePageFromEncoding(encoding ddv1.Encoding) byte {
 	}
 }
 
-// trimSpaceAndZeroBytes trims spaces, 0x00 and 0xff values off a byte slice.
+// trimSpaceAndZeroBytes trims spaces, control characters, and padding bytes off a byte slice.
 //
 // This function removes common padding and control characters that are often
 // used in tachograph string data to pad fixed-length fields. The trimmed
 // characters include:
-// - Whitespace: tab, newline, vertical tab, form feed, carriage return, space
+// - ASCII control characters: 0x00-0x1F (null, SOH, STX, ..., US)
+// - Whitespace: space (0x20)
 // - Control characters: 0x85 (NEL), 0xA0 (non-breaking space)
-// - Padding bytes: 0x00 (null), 0xFF (often used as padding in binary protocols)
+// - Padding bytes: 0xFF (often used as padding in binary protocols)
 func trimSpaceAndZeroBytes(b []byte) []byte {
 	// Define cutset as string - bytes.Trim handles this properly
-	cutset := "\t\n\v\f\r \x85\xA0\x00\xFF"
+	cutset := "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x85\xA0\xFF"
 	return bytes.Trim(b, cutset)
 }
 

--- a/internal/vu/overview_gen2_v2.go
+++ b/internal/vu/overview_gen2_v2.go
@@ -68,12 +68,13 @@ func unmarshalOverviewGen2V2(value []byte) (*vuv1.OverviewGen2V2, error) {
 	overview.SetVehicleIdentificationNumber(vin)
 	offset += bytesRead
 
-	// VehicleRegistrationNumberRecordArray (Gen2 V2 addition: 13-byte IA5String)
+	// VehicleRegistrationNumberRecordArray (Gen2 V2 addition)
+	// Real VUs write VehicleRegistrationIdentification (15 bytes) despite spec saying 13.
 	vrn, bytesRead, err := parseVehicleRegistrationNumberRecordArray(data, offset)
 	if err != nil {
 		return nil, fmt.Errorf("parse VehicleRegistrationNumberRecordArray: %w", err)
 	}
-	overview.SetVehicleRegistrationNumber(vrn)
+	overview.SetVehicleRegistrationIdentification(vrn)
 	offset += bytesRead
 
 	// CurrentDateTimeRecordArray
@@ -162,10 +163,10 @@ func (opts MarshalOptions) MarshalOverviewGen2V2(overview *vuv1.OverviewGen2V2) 
 	result = appendRecordArrayHeader(result, 0x03, uint16(len(vinData)), 1)
 	result = append(result, vinData...)
 
-	// VehicleRegistrationNumberRecordArray (13 bytes)
-	vrnData, err := marshalOpts.MarshalIa5StringValue(overview.GetVehicleRegistrationNumber())
+	// VehicleRegistrationIdentificationRecordArray (15 bytes)
+	vrnData, err := marshalOpts.MarshalVehicleRegistrationIdentification(overview.GetVehicleRegistrationIdentification())
 	if err != nil {
-		return nil, fmt.Errorf("marshal VRN: %w", err)
+		return nil, fmt.Errorf("marshal VRI: %w", err)
 	}
 	result = appendRecordArrayHeader(result, 0x04, uint16(len(vrnData)), 1)
 	result = append(result, vrnData...)
@@ -239,9 +240,9 @@ func (opts AnonymizeOptions) anonymizeOverviewGen2V2(overview *vuv1.OverviewGen2
 	result.SetMemberStateCertificate(nil)
 	result.SetVuCertificate(nil)
 
-	// Anonymize VIN and VRN
+	// Anonymize VIN and VRI
 	result.SetVehicleIdentificationNumber(ddOpts.AnonymizeIa5StringValue(overview.GetVehicleIdentificationNumber()))
-	result.SetVehicleRegistrationNumber(ddOpts.AnonymizeIa5StringValue(overview.GetVehicleRegistrationNumber()))
+	result.SetVehicleRegistrationIdentification(ddOpts.AnonymizeVehicleRegistrationIdentification(overview.GetVehicleRegistrationIdentification()))
 
 	// Preserve timestamps and period (no PII)
 	result.SetCurrentDateTime(overview.GetCurrentDateTime())
@@ -295,8 +296,11 @@ func (opts AnonymizeOptions) anonymizeOverviewGen2V2(overview *vuv1.OverviewGen2
 // ===== V2-specific parse helpers =====
 
 // parseVehicleRegistrationNumberRecordArray parses a VehicleRegistrationNumberRecordArray.
-// Expected: 1 record × 13 bytes (IA5String, Gen2 V2 only).
-func parseVehicleRegistrationNumberRecordArray(data []byte, offset int) (*ddv1.Ia5StringValue, int, error) {
+//
+// The spec says VehicleRegistrationNumber (13-byte IA5String), but real VUs
+// write VehicleRegistrationIdentification (15 bytes: nation + codepage + string).
+// We dispatch on the actual record size from the header.
+func parseVehicleRegistrationNumberRecordArray(data []byte, offset int) (*ddv1.VehicleRegistrationIdentification, int, error) {
 	_, recordSize, noOfRecords, headerSize, err := parseRecordArrayHeader(data, offset)
 	if err != nil {
 		return nil, 0, err
@@ -310,12 +314,30 @@ func parseVehicleRegistrationNumberRecordArray(data []byte, offset int) (*ddv1.I
 		return nil, 0, fmt.Errorf("insufficient data for VRN record")
 	}
 	var unmarshalOpts dd.UnmarshalOptions
-	vrn, err := unmarshalOpts.UnmarshalIa5StringValue(data[recordStart:recordEnd])
+	var vri *ddv1.VehicleRegistrationIdentification
+	switch recordSize {
+	case 15:
+		// VehicleRegistrationIdentification: 1 nation + 1 codepage + 13 string
+		vri, err = unmarshalOpts.UnmarshalVehicleRegistrationIdentification(data[recordStart:recordEnd])
+	case 13:
+		// VehicleRegistrationNumber: 13-byte IA5String (spec-compliant, unlikely in practice)
+		ia5, ia5Err := unmarshalOpts.UnmarshalIa5StringValue(data[recordStart:recordEnd])
+		if ia5Err != nil {
+			return nil, 0, fmt.Errorf("unmarshal VRN as IA5: %w", ia5Err)
+		}
+		// Wrap in VehicleRegistrationIdentification with default nation
+		vri = &ddv1.VehicleRegistrationIdentification{}
+		number := &ddv1.StringValue{}
+		number.SetValue(ia5.GetValue())
+		vri.SetNumber(number)
+	default:
+		return nil, 0, fmt.Errorf("unexpected VRN record size: %d (expected 13 or 15)", recordSize)
+	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("unmarshal VRN: %w", err)
 	}
 	totalSize := headerSize + int(recordSize)
-	return vrn, totalSize, nil
+	return vri, totalSize, nil
 }
 
 // parseDownloadActivityDataRecordArrayGen2V2 parses a VuDownloadActivityDataRecordArray for V2.

--- a/internal/vu/technical_data_gen2_v2.go
+++ b/internal/vu/technical_data_gen2_v2.go
@@ -1,7 +1,12 @@
 package vu
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/way-platform/tachograph-go/internal/dd"
 	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
@@ -142,13 +147,13 @@ func (opts MarshalOptions) MarshalTechnicalDataGen2V2(td *vuv1.TechnicalDataGen2
 	result = appendRecordArrayHeader(result, 0x03, 28, uint16(len(gnss)))
 	result = append(result, gnssData...)
 
-	// VuCalibrationRecordArray (N records × 168 bytes)
+	// VuCalibrationRecordArray (N records × 252 bytes)
 	calRecords := td.GetCalibrationRecords()
 	calData, err := marshalCalibrationRecordsGen2V2(marshalOpts, calRecords)
 	if err != nil {
 		return nil, fmt.Errorf("marshal VuCalibrationRecordArray: %w", err)
 	}
-	result = appendRecordArrayHeader(result, 0x04, 168, uint16(len(calRecords)))
+	result = appendRecordArrayHeader(result, 0x04, 252, uint16(len(calRecords)))
 	result = append(result, calData...)
 
 	// VuITSConsentRecordArray (N records × 20 bytes)
@@ -253,7 +258,7 @@ func (opts AnonymizeOptions) anonymizeTechnicalDataGen2V2(td *vuv1.TechnicalData
 		anon.SetUnrecognizedPurpose(cal.GetUnrecognizedPurpose())
 		anon.SetWorkshopName(ddOpts.AnonymizeStringValue(cal.GetWorkshopName()))
 		anon.SetWorkshopAddress(ddOpts.AnonymizeStringValue(cal.GetWorkshopAddress()))
-		anon.SetWorkshopCardNumberAndGeneration(ddOpts.AnonymizeFullCardNumberAndGeneration(cal.GetWorkshopCardNumberAndGeneration()))
+		anon.SetWorkshopCardNumber(ddOpts.AnonymizeFullCardNumber(cal.GetWorkshopCardNumber()))
 		anon.SetWorkshopCardExpiryDate(cal.GetWorkshopCardExpiryDate())
 		anon.SetVin(ddOpts.AnonymizeIa5StringValue(cal.GetVin()))
 		anon.SetVehicleRegistration(ddOpts.AnonymizeVehicleRegistrationIdentification(cal.GetVehicleRegistration()))
@@ -267,6 +272,14 @@ func (opts AnonymizeOptions) anonymizeTechnicalDataGen2V2(td *vuv1.TechnicalData
 		anon.SetOldTimeValue(ddOpts.AnonymizeTimestamp(cal.GetOldTimeValue()))
 		anon.SetNewTimeValue(ddOpts.AnonymizeTimestamp(cal.GetNewTimeValue()))
 		anon.SetNextCalibrationDate(ddOpts.AnonymizeTimestamp(cal.GetNextCalibrationDate()))
+		// V2 extension fields
+		anon.SetSensorSerialNumber(anonymizeExtendedSerialNumber(cal.GetSensorSerialNumber()))
+		anon.SetSensorGnssSerialNumber(anonymizeExtendedSerialNumber(cal.GetSensorGnssSerialNumber()))
+		anon.SetRcmSerialNumber(anonymizeExtendedSerialNumber(cal.GetRcmSerialNumber()))
+		anon.SetSealRecords(cal.GetSealRecords()) // Seal records have no PII
+		anon.SetLoadType(cal.GetLoadType())
+		anon.SetCalibrationCountry(cal.GetCalibrationCountry())
+		anon.SetCalibrationCountryTimestamp(cal.GetCalibrationCountryTimestamp())
 		anonCals[i] = anon
 	}
 	result.SetCalibrationRecords(anonCals)
@@ -334,17 +347,16 @@ func parseSensorExternalGNSSCoupledRecordArrayGen2(data []byte, offset int) ([]*
 }
 
 // parseCalibrationRecordArrayGen2V2 parses a VuCalibrationRecordArray for Gen2 V2.
+//
+// Dispatches based on record size from the RecordArray header:
+//   - 168 bytes: Gen2 V1 layout (FullCardNumberAndGeneration(19) + Datef expiry)
+//   - 252 bytes: Gen2 V2 layout (FullCardNumber(18) + TimeReal expiry + V2 extensions)
+//
+// Some Gen2 V2 VUs send 168-byte calibration records (V1 layout), so we must handle both.
 func parseCalibrationRecordArrayGen2V2(data []byte, offset int) ([]*vuv1.TechnicalDataGen2V2_CalibrationRecord, int, error) {
 	_, recordSize, noOfRecords, headerSize, err := parseRecordArrayHeader(data, offset)
 	if err != nil {
 		return nil, 0, err
-	}
-
-	// Gen2V1 sends 168 bytes; Gen2V2 sends 252 bytes (additional certification/GNSS fields).
-	// Parse the shared 168-byte prefix; extra bytes are preserved in the parent TV raw_data.
-	const minRecordSize = 168
-	if int(recordSize) < minRecordSize {
-		return nil, 0, fmt.Errorf("expected Gen2 CalibrationRecord size >= %d, got %d", minRecordSize, recordSize)
 	}
 
 	var unmarshalOpts dd.UnmarshalOptions
@@ -356,16 +368,263 @@ func parseCalibrationRecordArrayGen2V2(data []byte, offset int) ([]*vuv1.Technic
 		if recEnd > len(data) {
 			return nil, 0, fmt.Errorf("insufficient data for CalibrationRecord %d", i)
 		}
-		// Parse first 168 bytes; remaining Gen2V2-specific bytes are skipped semantically.
-		parsed, err := parseOneCalibrationRecordGen2(unmarshalOpts, data[recStart:recStart+minRecordSize])
+
+		var parsed *vuv1.TechnicalDataGen2V2_CalibrationRecord
+		switch {
+		case recordSize >= 252:
+			// Full V2 layout with extension fields
+			parsed, err = parseOneCalibrationRecordGen2V2(unmarshalOpts, data[recStart:recEnd])
+		case recordSize >= 168:
+			// V1 layout (168 bytes) — convert to V2 proto type
+			v1Rec, parseErr := parseOneCalibrationRecordGen2(unmarshalOpts, data[recStart:recEnd])
+			if parseErr != nil {
+				err = parseErr
+			} else {
+				parsed = gen2V1CalibrationToV2(v1Rec)
+			}
+		default:
+			err = fmt.Errorf("unexpected CalibrationRecord size %d (want >= 168)", recordSize)
+		}
 		if err != nil {
 			return nil, 0, fmt.Errorf("CalibrationRecord %d: %w", i, err)
 		}
-		records = append(records, gen2CalibrationToV2(parsed))
+		records = append(records, parsed)
 		recStart = recEnd
 	}
 
 	return records, headerSize + int(recordSize)*int(noOfRecords), nil
+}
+
+// parseOneCalibrationRecordGen2V2 parses a single Gen2 V2 VuCalibrationRecord.
+//
+// Gen2 V2 layout (252 bytes):
+//
+//	calibrationPurpose CalibrationPurpose                            -- 1 byte (offset 0)
+//	workshopName Name                                                -- 36 bytes (offset 1)
+//	workshopAddress Address                                          -- 36 bytes (offset 37)
+//	workshopCardNumber FullCardNumber                                -- 18 bytes (offset 73)
+//	workshopCardExpiryDate TimeReal                                  -- 4 bytes (offset 91)
+//	vehicleIdentificationNumber VehicleIdentificationNumber          -- 17 bytes (offset 95)
+//	vehicleRegistrationIdentification VehicleRegistrationIdentification -- 15 bytes (offset 112)
+//	wVehicleCharacteristicConstant W-VehicleCharacteristicConstant   -- 2 bytes (offset 127)
+//	kConstantOfRecordingEquipment K-ConstantOfRecordingEquipment     -- 2 bytes (offset 129)
+//	lTyreCircumference L-TyreCircumference                           -- 2 bytes (offset 131)
+//	tyreSize TyreSize                                                -- 15 bytes (offset 133)
+//	authorisedSpeed SpeedAuthorised                                  -- 1 byte (offset 148)
+//	oldOdometerValue OdometerShort                                   -- 3 bytes (offset 149)
+//	newOdometerValue OdometerShort                                   -- 3 bytes (offset 152)
+//	oldTimeValue TimeReal                                            -- 4 bytes (offset 155)
+//	newTimeValue TimeReal                                            -- 4 bytes (offset 159)
+//	nextCalibrationDate TimeReal                                     -- 4 bytes (offset 163)
+//	sensorSerialNumber ExtendedSerialNumber                          -- 8 bytes (offset 167)
+//	sensorGNSSSerialNumber ExtendedSerialNumber                      -- 8 bytes (offset 175)
+//	rcmSerialNumber ExtendedSerialNumber                             -- 8 bytes (offset 183)
+//	sealDataVu SealDataVu (5 × SealRecord(11))                      -- 55 bytes (offset 191)
+//	byDefaultLoadType LoadType                                       -- 1 byte (offset 246)
+//	calibrationCountry NationNumeric                                 -- 1 byte (offset 247)
+//	calibrationCountryTimestamp TimeReal                              -- 4 bytes (offset 248)
+func parseOneCalibrationRecordGen2V2(opts dd.UnmarshalOptions, data []byte) (*vuv1.TechnicalDataGen2V2_CalibrationRecord, error) {
+	const (
+		idxPurpose          = 0
+		idxWorkshopName     = 1
+		lenWorkshopName     = 36
+		idxWorkshopAddress  = 37
+		lenWorkshopAddress  = 36
+		idxWorkshopCard     = 73
+		lenWorkshopCard     = 18
+		idxCardExpiry       = 91
+		lenCardExpiry       = 4
+		idxVIN              = 95
+		lenVIN              = 17
+		idxVehicleReg       = 112
+		lenVehicleReg       = 15
+		idxWVehicleChar     = 127
+		idxKConstant        = 129
+		idxLTyreCirc        = 131
+		idxTyreSize         = 133
+		lenTyreSize         = 15
+		idxAuthorisedSpeed  = 148
+		idxOldOdometer      = 149
+		idxNewOdometer      = 152
+		idxOldTimeValue     = 155
+		idxNewTimeValue     = 159
+		idxNextCalDate      = 163
+		idxSensorSerial     = 167
+		idxGNSSSerial       = 175
+		idxRCMSerial        = 183
+		idxSealData         = 191
+		lenSealRecord       = 11
+		numSealRecords      = 5
+		lenSealData         = numSealRecords * lenSealRecord // 55
+		idxLoadType         = idxSealData + lenSealData      // 246
+		idxCalCountry       = 247
+		idxCalCountryTs     = 248
+		lenRecord           = 252
+	)
+
+	if len(data) < lenRecord {
+		return nil, fmt.Errorf("invalid Gen2V2 CalibrationRecord size: got %d, want >= %d", len(data), lenRecord)
+	}
+
+	rec := &vuv1.TechnicalDataGen2V2_CalibrationRecord{}
+
+	// calibrationPurpose (1 byte)
+	purposeValue := int32(data[idxPurpose])
+	purpose, err := dd.UnmarshalEnum[ddv1.CalibrationPurpose](byte(purposeValue))
+	if err != nil {
+		rec.SetUnrecognizedPurpose(purposeValue)
+		rec.SetPurpose(ddv1.CalibrationPurpose_CALIBRATION_PURPOSE_UNSPECIFIED)
+	} else {
+		rec.SetPurpose(purpose)
+	}
+
+	// workshopName (36 bytes)
+	workshopName, err := opts.UnmarshalStringValue(data[idxWorkshopName : idxWorkshopName+lenWorkshopName])
+	if err != nil {
+		return nil, fmt.Errorf("workshop name: %w", err)
+	}
+	rec.SetWorkshopName(workshopName)
+
+	// workshopAddress (36 bytes)
+	workshopAddr, err := opts.UnmarshalStringValue(data[idxWorkshopAddress : idxWorkshopAddress+lenWorkshopAddress])
+	if err != nil {
+		return nil, fmt.Errorf("workshop address: %w", err)
+	}
+	rec.SetWorkshopAddress(workshopAddr)
+
+	// workshopCardNumber (18 bytes, FullCardNumber)
+	workshopCard, err := opts.UnmarshalFullCardNumber(data[idxWorkshopCard : idxWorkshopCard+lenWorkshopCard])
+	if err != nil {
+		return nil, fmt.Errorf("workshop card number: %w", err)
+	}
+	rec.SetWorkshopCardNumber(workshopCard)
+
+	// workshopCardExpiryDate (4 bytes, TimeReal)
+	expiryDate, err := opts.UnmarshalTimeReal(data[idxCardExpiry : idxCardExpiry+lenCardExpiry])
+	if err != nil {
+		return nil, fmt.Errorf("workshop card expiry date: %w", err)
+	}
+	rec.SetWorkshopCardExpiryDate(expiryDate)
+
+	// VIN (17 bytes)
+	vin, err := opts.UnmarshalIa5StringValue(data[idxVIN : idxVIN+lenVIN])
+	if err != nil {
+		return nil, fmt.Errorf("VIN: %w", err)
+	}
+	rec.SetVin(vin)
+
+	// vehicleRegistration (15 bytes)
+	vehicleReg, err := opts.UnmarshalVehicleRegistrationIdentification(data[idxVehicleReg : idxVehicleReg+lenVehicleReg])
+	if err != nil {
+		return nil, fmt.Errorf("vehicle registration: %w", err)
+	}
+	rec.SetVehicleRegistration(vehicleReg)
+
+	// W-Vehicle Characteristic Constant (2 bytes)
+	rec.SetWVehicleCharacteristicConstant(int32(binary.BigEndian.Uint16(data[idxWVehicleChar : idxWVehicleChar+2])))
+
+	// K-Constant (2 bytes)
+	rec.SetKConstantOfRecordingEquipment(int32(binary.BigEndian.Uint16(data[idxKConstant : idxKConstant+2])))
+
+	// L-Tyre Circumference (2 bytes)
+	rec.SetLTyreCircumferenceEighthsMm(int32(binary.BigEndian.Uint16(data[idxLTyreCirc : idxLTyreCirc+2])))
+
+	// tyreSize (15 bytes)
+	tyreSize, err := opts.UnmarshalIa5StringValue(data[idxTyreSize : idxTyreSize+lenTyreSize])
+	if err != nil {
+		return nil, fmt.Errorf("tyre size: %w", err)
+	}
+	rec.SetTyreSize(tyreSize)
+
+	// authorisedSpeed (1 byte)
+	rec.SetAuthorisedSpeedKmh(int32(data[idxAuthorisedSpeed]))
+
+	// oldOdometerValue (3 bytes, 24-bit big-endian)
+	rec.SetOldOdometerValueKm(int32(data[idxOldOdometer])<<16 |
+		int32(data[idxOldOdometer+1])<<8 |
+		int32(data[idxOldOdometer+2]))
+
+	// newOdometerValue (3 bytes)
+	rec.SetNewOdometerValueKm(int32(data[idxNewOdometer])<<16 |
+		int32(data[idxNewOdometer+1])<<8 |
+		int32(data[idxNewOdometer+2]))
+
+	// oldTimeValue (4 bytes)
+	oldTime, err := opts.UnmarshalTimeReal(data[idxOldTimeValue : idxOldTimeValue+4])
+	if err != nil {
+		return nil, fmt.Errorf("old time value: %w", err)
+	}
+	rec.SetOldTimeValue(oldTime)
+
+	// newTimeValue (4 bytes)
+	newTime, err := opts.UnmarshalTimeReal(data[idxNewTimeValue : idxNewTimeValue+4])
+	if err != nil {
+		return nil, fmt.Errorf("new time value: %w", err)
+	}
+	rec.SetNewTimeValue(newTime)
+
+	// nextCalibrationDate (4 bytes)
+	nextCal, err := opts.UnmarshalTimeReal(data[idxNextCalDate : idxNextCalDate+4])
+	if err != nil {
+		return nil, fmt.Errorf("next calibration date: %w", err)
+	}
+	rec.SetNextCalibrationDate(nextCal)
+
+	// === V2 extension ===
+
+	// sensorSerialNumber (8 bytes)
+	sensorSN, err := opts.UnmarshalExtendedSerialNumber(data[idxSensorSerial : idxSensorSerial+8])
+	if err != nil {
+		return nil, fmt.Errorf("sensor serial number: %w", err)
+	}
+	rec.SetSensorSerialNumber(sensorSN)
+
+	// sensorGNSSSerialNumber (8 bytes)
+	gnssSN, err := opts.UnmarshalExtendedSerialNumber(data[idxGNSSSerial : idxGNSSSerial+8])
+	if err != nil {
+		return nil, fmt.Errorf("GNSS serial number: %w", err)
+	}
+	rec.SetSensorGnssSerialNumber(gnssSN)
+
+	// rcmSerialNumber (8 bytes)
+	rcmSN, err := opts.UnmarshalExtendedSerialNumber(data[idxRCMSerial : idxRCMSerial+8])
+	if err != nil {
+		return nil, fmt.Errorf("RCM serial number: %w", err)
+	}
+	rec.SetRcmSerialNumber(rcmSN)
+
+	// sealDataVu (55 bytes = 5 × SealRecord(11))
+	sealRecords := make([]*vuv1.TechnicalDataGen2V2_SealRecord, numSealRecords)
+	for s := range numSealRecords {
+		sealStart := idxSealData + s*lenSealRecord
+		sealRec := &vuv1.TechnicalDataGen2V2_SealRecord{}
+
+		equipType, eqErr := dd.UnmarshalEnum[ddv1.EquipmentType](data[sealStart])
+		if eqErr != nil {
+			sealRec.SetUnrecognizedEquipmentType(int32(data[sealStart]))
+		} else {
+			sealRec.SetEquipmentType(equipType)
+		}
+		sealRec.SetManufacturerCode(string(bytes.Trim(data[sealStart+1:sealStart+3], "\x00\xff ")))
+		sealRec.SetSealIdentifier(string(bytes.Trim(data[sealStart+3:sealStart+11], "\x00\xff ")))
+		sealRecords[s] = sealRec
+	}
+	rec.SetSealRecords(sealRecords)
+
+	// byDefaultLoadType (1 byte)
+	rec.SetLoadType(int32(data[idxLoadType]))
+
+	// calibrationCountry (1 byte)
+	rec.SetCalibrationCountry(ddv1.NationNumeric(int32(data[idxCalCountry])))
+
+	// calibrationCountryTimestamp (4 bytes)
+	calCountryTs, err := opts.UnmarshalTimeReal(data[idxCalCountryTs : idxCalCountryTs+4])
+	if err != nil {
+		return nil, fmt.Errorf("calibration country timestamp: %w", err)
+	}
+	rec.SetCalibrationCountryTimestamp(calCountryTs)
+
+	return rec, nil
 }
 
 // parseItsConsentRecordArrayGen2V2 parses a VuITSConsentRecordArray.
@@ -517,17 +776,178 @@ func marshalCoupledGnssRecordsGen2V2(opts dd.MarshalOptions, gnssRecords []*vuv1
 	return result, nil
 }
 
-// marshalCalibrationRecordsGen2V2 marshals V2 calibration records to binary.
+// marshalCalibrationRecordsGen2V2 marshals V2 calibration records to binary (252 bytes each).
 func marshalCalibrationRecordsGen2V2(opts dd.MarshalOptions, records []*vuv1.TechnicalDataGen2V2_CalibrationRecord) ([]byte, error) {
-	result := make([]byte, 0, len(records)*168)
+	const lenRecord = 252
+	result := make([]byte, 0, len(records)*lenRecord)
 	for i, rec := range records {
-		b, err := marshalOneCalibrationRecordGen2(opts, gen2CalibrationFromV2(rec))
+		b, err := marshalOneCalibrationRecordGen2V2(opts, rec)
 		if err != nil {
 			return nil, fmt.Errorf("calibration record %d: %w", i, err)
 		}
 		result = append(result, b...)
 	}
 	return result, nil
+}
+
+// marshalOneCalibrationRecordGen2V2 marshals a single Gen2 V2 calibration record to 252 bytes.
+func marshalOneCalibrationRecordGen2V2(opts dd.MarshalOptions, rec *vuv1.TechnicalDataGen2V2_CalibrationRecord) ([]byte, error) {
+	const lenRecord = 252
+	buf := make([]byte, lenRecord)
+
+	// calibrationPurpose (1 byte)
+	if rec.GetUnrecognizedPurpose() != 0 {
+		buf[0] = byte(rec.GetUnrecognizedPurpose())
+	} else {
+		buf[0] = byte(rec.GetPurpose())
+	}
+
+	// workshopName (36 bytes at offset 1)
+	nameBytes, err := opts.MarshalStringValue(rec.GetWorkshopName())
+	if err != nil {
+		return nil, fmt.Errorf("workshop name: %w", err)
+	}
+	copy(buf[1:37], nameBytes)
+
+	// workshopAddress (36 bytes at offset 37)
+	addrBytes, err := opts.MarshalStringValue(rec.GetWorkshopAddress())
+	if err != nil {
+		return nil, fmt.Errorf("workshop address: %w", err)
+	}
+	copy(buf[37:73], addrBytes)
+
+	// workshopCardNumber (18 bytes at offset 73)
+	cardBytes, err := opts.MarshalFullCardNumber(rec.GetWorkshopCardNumber())
+	if err != nil {
+		return nil, fmt.Errorf("workshop card number: %w", err)
+	}
+	copy(buf[73:91], cardBytes)
+
+	// workshopCardExpiryDate (4 bytes at offset 91)
+	expiryBytes, err := opts.MarshalTimeReal(rec.GetWorkshopCardExpiryDate())
+	if err != nil {
+		return nil, fmt.Errorf("workshop card expiry: %w", err)
+	}
+	copy(buf[91:95], expiryBytes)
+
+	// VIN (17 bytes at offset 95)
+	vinBytes, err := opts.MarshalIa5StringValue(rec.GetVin())
+	if err != nil {
+		return nil, fmt.Errorf("VIN: %w", err)
+	}
+	copy(buf[95:112], vinBytes)
+
+	// vehicleRegistration (15 bytes at offset 112)
+	vregBytes, err := opts.MarshalVehicleRegistrationIdentification(rec.GetVehicleRegistration())
+	if err != nil {
+		return nil, fmt.Errorf("vehicle registration: %w", err)
+	}
+	copy(buf[112:127], vregBytes)
+
+	// W-Vehicle Characteristic Constant (2 bytes at offset 127)
+	binary.BigEndian.PutUint16(buf[127:129], uint16(rec.GetWVehicleCharacteristicConstant()))
+
+	// K-Constant (2 bytes at offset 129)
+	binary.BigEndian.PutUint16(buf[129:131], uint16(rec.GetKConstantOfRecordingEquipment()))
+
+	// L-Tyre Circumference (2 bytes at offset 131)
+	binary.BigEndian.PutUint16(buf[131:133], uint16(rec.GetLTyreCircumferenceEighthsMm()))
+
+	// tyreSize (15 bytes at offset 133)
+	tyreSizeBytes, err := opts.MarshalIa5StringValue(rec.GetTyreSize())
+	if err != nil {
+		return nil, fmt.Errorf("tyre size: %w", err)
+	}
+	copy(buf[133:148], tyreSizeBytes)
+
+	// authorisedSpeed (1 byte at offset 148)
+	buf[148] = byte(rec.GetAuthorisedSpeedKmh())
+
+	// oldOdometerValue (3 bytes at offset 149)
+	v := rec.GetOldOdometerValueKm()
+	buf[149] = byte(v >> 16)
+	buf[150] = byte(v >> 8)
+	buf[151] = byte(v)
+
+	// newOdometerValue (3 bytes at offset 152)
+	v = rec.GetNewOdometerValueKm()
+	buf[152] = byte(v >> 16)
+	buf[153] = byte(v >> 8)
+	buf[154] = byte(v)
+
+	// oldTimeValue (4 bytes at offset 155)
+	oldTimeBytes, err := opts.MarshalTimeReal(rec.GetOldTimeValue())
+	if err != nil {
+		return nil, fmt.Errorf("old time value: %w", err)
+	}
+	copy(buf[155:159], oldTimeBytes)
+
+	// newTimeValue (4 bytes at offset 159)
+	newTimeBytes, err := opts.MarshalTimeReal(rec.GetNewTimeValue())
+	if err != nil {
+		return nil, fmt.Errorf("new time value: %w", err)
+	}
+	copy(buf[159:163], newTimeBytes)
+
+	// nextCalibrationDate (4 bytes at offset 163)
+	nextCalBytes, err := opts.MarshalTimeReal(rec.GetNextCalibrationDate())
+	if err != nil {
+		return nil, fmt.Errorf("next calibration date: %w", err)
+	}
+	copy(buf[163:167], nextCalBytes)
+
+	// === V2 extension ===
+
+	// sensorSerialNumber (8 bytes at offset 167)
+	sensorSNBytes, err := opts.MarshalExtendedSerialNumber(rec.GetSensorSerialNumber())
+	if err != nil {
+		return nil, fmt.Errorf("sensor serial number: %w", err)
+	}
+	copy(buf[167:175], sensorSNBytes)
+
+	// sensorGNSSSerialNumber (8 bytes at offset 175)
+	gnssSNBytes, err := opts.MarshalExtendedSerialNumber(rec.GetSensorGnssSerialNumber())
+	if err != nil {
+		return nil, fmt.Errorf("GNSS serial number: %w", err)
+	}
+	copy(buf[175:183], gnssSNBytes)
+
+	// rcmSerialNumber (8 bytes at offset 183)
+	rcmSNBytes, err := opts.MarshalExtendedSerialNumber(rec.GetRcmSerialNumber())
+	if err != nil {
+		return nil, fmt.Errorf("RCM serial number: %w", err)
+	}
+	copy(buf[183:191], rcmSNBytes)
+
+	// sealDataVu (55 bytes at offset 191 = 5 × SealRecord(11))
+	for s, seal := range rec.GetSealRecords() {
+		if s >= 5 {
+			break
+		}
+		off := 191 + s*11
+		if seal.GetUnrecognizedEquipmentType() != 0 {
+			buf[off] = byte(seal.GetUnrecognizedEquipmentType())
+		} else {
+			buf[off] = byte(seal.GetEquipmentType())
+		}
+		copy(buf[off+1:off+3], []byte(seal.GetManufacturerCode()))
+		copy(buf[off+3:off+11], []byte(seal.GetSealIdentifier()))
+	}
+
+	// byDefaultLoadType (1 byte at offset 246)
+	buf[246] = byte(rec.GetLoadType())
+
+	// calibrationCountry (1 byte at offset 247)
+	buf[247] = byte(rec.GetCalibrationCountry())
+
+	// calibrationCountryTimestamp (4 bytes at offset 248)
+	calCountryTsBytes, err := opts.MarshalTimeReal(rec.GetCalibrationCountryTimestamp())
+	if err != nil {
+		return nil, fmt.Errorf("calibration country timestamp: %w", err)
+	}
+	copy(buf[248:252], calCountryTsBytes)
+
+	return buf, nil
 }
 
 // marshalItsConsentRecordsGen2V2 marshals V2 ITS consent records to binary.
@@ -599,15 +1019,26 @@ func sensorPairedToGen2V2(s *ddv1.SensorPaired) *vuv1.TechnicalDataGen2V2_Paired
 	return sensor
 }
 
-// gen2CalibrationToV2 converts a parsed gen2CalibrationRecord to the V2 proto type.
-func gen2CalibrationToV2(r gen2CalibrationRecord) *vuv1.TechnicalDataGen2V2_CalibrationRecord {
+// gen2V1CalibrationToV2 converts a V1-parsed gen2CalibrationRecord to the V2 proto type.
+//
+// Used when Gen2 V2 VUs send 168-byte (V1 layout) calibration records.
+// The V2 extension fields are left as zero values.
+func gen2V1CalibrationToV2(r gen2CalibrationRecord) *vuv1.TechnicalDataGen2V2_CalibrationRecord {
 	rec := &vuv1.TechnicalDataGen2V2_CalibrationRecord{}
 	rec.SetPurpose(r.purpose)
 	rec.SetUnrecognizedPurpose(r.unrecognizedPurpose)
 	rec.SetWorkshopName(r.workshopName)
 	rec.SetWorkshopAddress(r.workshopAddress)
-	rec.SetWorkshopCardNumberAndGeneration(r.workshopCardNumberAndGen)
-	rec.SetWorkshopCardExpiryDate(r.workshopCardExpiryDate)
+	// V1 has FullCardNumberAndGeneration(19); V2 proto has FullCardNumber(18).
+	// Extract just the FullCardNumber from FullCardNumberAndGeneration.
+	if fcng := r.workshopCardNumberAndGen; fcng != nil {
+		rec.SetWorkshopCardNumber(fcng.GetFullCardNumber())
+	}
+	// V1 has Datef expiry; V2 proto has Timestamp.
+	if d := r.workshopCardExpiryDate; d != nil {
+		t := time.Date(int(d.GetYear()), time.Month(d.GetMonth()), int(d.GetDay()), 0, 0, 0, 0, time.UTC)
+		rec.SetWorkshopCardExpiryDate(timestamppb.New(t))
+	}
 	rec.SetVin(r.vin)
 	rec.SetVehicleRegistration(r.vehicleRegistration)
 	rec.SetWVehicleCharacteristicConstant(r.wVehicleCharConst)
@@ -623,29 +1054,14 @@ func gen2CalibrationToV2(r gen2CalibrationRecord) *vuv1.TechnicalDataGen2V2_Cali
 	return rec
 }
 
-// gen2CalibrationFromV2 converts a V2 CalibrationRecord to the shared gen2CalibrationRecord.
-func gen2CalibrationFromV2(rec *vuv1.TechnicalDataGen2V2_CalibrationRecord) gen2CalibrationRecord {
-	if rec == nil {
-		return gen2CalibrationRecord{}
+// anonymizeExtendedSerialNumber anonymizes an ExtendedSerialNumber by zeroing the serial number.
+func anonymizeExtendedSerialNumber(esn *ddv1.ExtendedSerialNumber) *ddv1.ExtendedSerialNumber {
+	if esn == nil {
+		return nil
 	}
-	return gen2CalibrationRecord{
-		purpose:                  rec.GetPurpose(),
-		unrecognizedPurpose:      rec.GetUnrecognizedPurpose(),
-		workshopName:             rec.GetWorkshopName(),
-		workshopAddress:          rec.GetWorkshopAddress(),
-		workshopCardNumberAndGen: rec.GetWorkshopCardNumberAndGeneration(),
-		workshopCardExpiryDate:   rec.GetWorkshopCardExpiryDate(),
-		vin:                      rec.GetVin(),
-		vehicleRegistration:      rec.GetVehicleRegistration(),
-		wVehicleCharConst:        rec.GetWVehicleCharacteristicConstant(),
-		kConstantRecordEquip:     rec.GetKConstantOfRecordingEquipment(),
-		lTyreCircumference:       rec.GetLTyreCircumferenceEighthsMm(),
-		tyreSize:                 rec.GetTyreSize(),
-		authorisedSpeedKmh:       rec.GetAuthorisedSpeedKmh(),
-		oldOdometerValueKm:       rec.GetOldOdometerValueKm(),
-		newOdometerValueKm:       rec.GetNewOdometerValueKm(),
-		oldTimeValue:             rec.GetOldTimeValue(),
-		newTimeValue:             rec.GetNewTimeValue(),
-		nextCalibrationDate:      rec.GetNextCalibrationDate(),
-	}
+	anon := &ddv1.ExtendedSerialNumber{}
+	anon.SetType(esn.GetType())
+	anon.SetManufacturerCode(esn.GetManufacturerCode())
+	anon.SetSerialNumber(0)
+	return anon
 }

--- a/internal/vu/testdata/records/003-anonymized/000-OVERVIEW_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/000-OVERVIEW_GEN2_V2.golden.json
@@ -5,9 +5,13 @@
     "length": 17,
     "value": "*****************"
   },
-  "vehicleRegistrationNumber": {
-    "length": 15,
-    "value": "***************"
+  "vehicleRegistrationIdentification": {
+    "nation": "PORTUGAL",
+    "number": {
+      "encoding": "ENCODING_UNRECOGNIZED",
+      "length": 13,
+      "value": "*************"
+    }
   },
   "currentDateTime": "2026-03-10T22:42:52Z",
   "downloadablePeriod": {

--- a/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -47,36 +47,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -116,36 +109,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -185,36 +171,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -254,36 +233,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"

--- a/internal/vu/testdata/records/004-anonymized/000-OVERVIEW_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/000-OVERVIEW_GEN2_V2.golden.json
@@ -5,9 +5,13 @@
     "length": 17,
     "value": "*****************"
   },
-  "vehicleRegistrationNumber": {
-    "length": 15,
-    "value": "***************"
+  "vehicleRegistrationIdentification": {
+    "nation": "PORTUGAL",
+    "number": {
+      "encoding": "ENCODING_UNRECOGNIZED",
+      "length": 13,
+      "value": "*************"
+    }
   },
   "currentDateTime": "2026-03-11T22:52:29Z",
   "downloadablePeriod": {

--- a/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -47,36 +47,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -116,36 +109,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -185,36 +171,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"
@@ -254,36 +233,29 @@
         "length": 35,
         "value": "***********************************"
       },
-      "workshopCardNumberAndGeneration": {
-        "fullCardNumber": {
-          "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+      "workshopCardNumber": {
+        "cardType": "WORKSHOP_CARD",
+        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "ownerIdentification": {
           "ownerIdentification": {
-            "ownerIdentification": {
-              "length": 13,
-              "value": "*************"
-            },
-            "consecutiveIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "replacementIndex": {
-              "length": 1,
-              "value": "*"
-            },
-            "renewalIndex": {
-              "length": 1,
-              "value": "*"
-            }
+            "length": 13,
+            "value": "*************"
+          },
+          "consecutiveIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "replacementIndex": {
+            "length": 1,
+            "value": "*"
+          },
+          "renewalIndex": {
+            "length": 1,
+            "value": "*"
           }
-        },
-        "generation": "GENERATION_UNSPECIFIED"
+        }
       },
-      "workshopCardExpiryDate": {
-        "year": 3265,
-        "month": 65,
-        "day": 57
-      },
+      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
       "vin": {
         "length": 17,
         "value": "*****************"

--- a/proto/gen/go/wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.pb.go
@@ -45,25 +45,25 @@ const (
 //	    signatureRecordArray SignatureRecordArray
 //	}
 type OverviewGen2V2 struct {
-	state                                  protoimpl.MessageState              `protogen:"opaque.v1"`
-	xxx_hidden_MemberStateCertificate      []byte                              `protobuf:"bytes,1,opt,name=member_state_certificate,json=memberStateCertificate"`
-	xxx_hidden_VuCertificate               []byte                              `protobuf:"bytes,2,opt,name=vu_certificate,json=vuCertificate"`
-	xxx_hidden_VehicleIdentificationNumber *v1.Ia5StringValue                  `protobuf:"bytes,3,opt,name=vehicle_identification_number,json=vehicleIdentificationNumber"`
-	xxx_hidden_VehicleRegistrationNumber   *v1.Ia5StringValue                  `protobuf:"bytes,4,opt,name=vehicle_registration_number,json=vehicleRegistrationNumber"`
-	xxx_hidden_CurrentDateTime             *timestamppb.Timestamp              `protobuf:"bytes,5,opt,name=current_date_time,json=currentDateTime"`
-	xxx_hidden_DownloadablePeriod          *v1.DownloadablePeriod              `protobuf:"bytes,6,opt,name=downloadable_period,json=downloadablePeriod"`
-	xxx_hidden_DriverSlotCard              v1.SlotCardType                     `protobuf:"varint,7,opt,name=driver_slot_card,json=driverSlotCard,enum=wayplatform.connect.tachograph.dd.v1.SlotCardType"`
-	xxx_hidden_CoDriverSlotCard            v1.SlotCardType                     `protobuf:"varint,8,opt,name=co_driver_slot_card,json=coDriverSlotCard,enum=wayplatform.connect.tachograph.dd.v1.SlotCardType"`
-	xxx_hidden_DownloadActivities          *[]*OverviewGen2V2_DownloadActivity `protobuf:"bytes,9,rep,name=download_activities,json=downloadActivities"`
-	xxx_hidden_CompanyLocks                *[]*OverviewGen2V2_CompanyLock      `protobuf:"bytes,10,rep,name=company_locks,json=companyLocks"`
-	xxx_hidden_ControlActivities           *[]*OverviewGen2V2_ControlActivity  `protobuf:"bytes,11,rep,name=control_activities,json=controlActivities"`
-	xxx_hidden_Signature                   []byte                              `protobuf:"bytes,12,opt,name=signature"`
-	xxx_hidden_RawData                     []byte                              `protobuf:"bytes,13,opt,name=raw_data,json=rawData"`
-	xxx_hidden_Authentication              *v11.Authentication                 `protobuf:"bytes,99,opt,name=authentication"`
-	XXX_raceDetectHookData                 protoimpl.RaceDetectHookData
-	XXX_presence                           [1]uint32
-	unknownFields                          protoimpl.UnknownFields
-	sizeCache                              protoimpl.SizeCache
+	state                                        protoimpl.MessageState                `protogen:"opaque.v1"`
+	xxx_hidden_MemberStateCertificate            []byte                                `protobuf:"bytes,1,opt,name=member_state_certificate,json=memberStateCertificate"`
+	xxx_hidden_VuCertificate                     []byte                                `protobuf:"bytes,2,opt,name=vu_certificate,json=vuCertificate"`
+	xxx_hidden_VehicleIdentificationNumber       *v1.Ia5StringValue                    `protobuf:"bytes,3,opt,name=vehicle_identification_number,json=vehicleIdentificationNumber"`
+	xxx_hidden_VehicleRegistrationIdentification *v1.VehicleRegistrationIdentification `protobuf:"bytes,4,opt,name=vehicle_registration_identification,json=vehicleRegistrationIdentification"`
+	xxx_hidden_CurrentDateTime                   *timestamppb.Timestamp                `protobuf:"bytes,5,opt,name=current_date_time,json=currentDateTime"`
+	xxx_hidden_DownloadablePeriod                *v1.DownloadablePeriod                `protobuf:"bytes,6,opt,name=downloadable_period,json=downloadablePeriod"`
+	xxx_hidden_DriverSlotCard                    v1.SlotCardType                       `protobuf:"varint,7,opt,name=driver_slot_card,json=driverSlotCard,enum=wayplatform.connect.tachograph.dd.v1.SlotCardType"`
+	xxx_hidden_CoDriverSlotCard                  v1.SlotCardType                       `protobuf:"varint,8,opt,name=co_driver_slot_card,json=coDriverSlotCard,enum=wayplatform.connect.tachograph.dd.v1.SlotCardType"`
+	xxx_hidden_DownloadActivities                *[]*OverviewGen2V2_DownloadActivity   `protobuf:"bytes,9,rep,name=download_activities,json=downloadActivities"`
+	xxx_hidden_CompanyLocks                      *[]*OverviewGen2V2_CompanyLock        `protobuf:"bytes,10,rep,name=company_locks,json=companyLocks"`
+	xxx_hidden_ControlActivities                 *[]*OverviewGen2V2_ControlActivity    `protobuf:"bytes,11,rep,name=control_activities,json=controlActivities"`
+	xxx_hidden_Signature                         []byte                                `protobuf:"bytes,12,opt,name=signature"`
+	xxx_hidden_RawData                           []byte                                `protobuf:"bytes,13,opt,name=raw_data,json=rawData"`
+	xxx_hidden_Authentication                    *v11.Authentication                   `protobuf:"bytes,99,opt,name=authentication"`
+	XXX_raceDetectHookData                       protoimpl.RaceDetectHookData
+	XXX_presence                                 [1]uint32
+	unknownFields                                protoimpl.UnknownFields
+	sizeCache                                    protoimpl.SizeCache
 }
 
 func (x *OverviewGen2V2) Reset() {
@@ -112,9 +112,9 @@ func (x *OverviewGen2V2) GetVehicleIdentificationNumber() *v1.Ia5StringValue {
 	return nil
 }
 
-func (x *OverviewGen2V2) GetVehicleRegistrationNumber() *v1.Ia5StringValue {
+func (x *OverviewGen2V2) GetVehicleRegistrationIdentification() *v1.VehicleRegistrationIdentification {
 	if x != nil {
-		return x.xxx_hidden_VehicleRegistrationNumber
+		return x.xxx_hidden_VehicleRegistrationIdentification
 	}
 	return nil
 }
@@ -219,8 +219,8 @@ func (x *OverviewGen2V2) SetVehicleIdentificationNumber(v *v1.Ia5StringValue) {
 	x.xxx_hidden_VehicleIdentificationNumber = v
 }
 
-func (x *OverviewGen2V2) SetVehicleRegistrationNumber(v *v1.Ia5StringValue) {
-	x.xxx_hidden_VehicleRegistrationNumber = v
+func (x *OverviewGen2V2) SetVehicleRegistrationIdentification(v *v1.VehicleRegistrationIdentification) {
+	x.xxx_hidden_VehicleRegistrationIdentification = v
 }
 
 func (x *OverviewGen2V2) SetCurrentDateTime(v *timestamppb.Timestamp) {
@@ -294,11 +294,11 @@ func (x *OverviewGen2V2) HasVehicleIdentificationNumber() bool {
 	return x.xxx_hidden_VehicleIdentificationNumber != nil
 }
 
-func (x *OverviewGen2V2) HasVehicleRegistrationNumber() bool {
+func (x *OverviewGen2V2) HasVehicleRegistrationIdentification() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_VehicleRegistrationNumber != nil
+	return x.xxx_hidden_VehicleRegistrationIdentification != nil
 }
 
 func (x *OverviewGen2V2) HasCurrentDateTime() bool {
@@ -364,8 +364,8 @@ func (x *OverviewGen2V2) ClearVehicleIdentificationNumber() {
 	x.xxx_hidden_VehicleIdentificationNumber = nil
 }
 
-func (x *OverviewGen2V2) ClearVehicleRegistrationNumber() {
-	x.xxx_hidden_VehicleRegistrationNumber = nil
+func (x *OverviewGen2V2) ClearVehicleRegistrationIdentification() {
+	x.xxx_hidden_VehicleRegistrationIdentification = nil
 }
 
 func (x *OverviewGen2V2) ClearCurrentDateTime() {
@@ -419,14 +419,14 @@ type OverviewGen2V2_builder struct {
 	//
 	//	VehicleIdentificationNumber ::= IA5String(SIZE(17))
 	VehicleIdentificationNumber *v1.Ia5StringValue
-	// The vehicle registration number only (Gen2 V2 addition).
+	// The vehicle registration identification (Gen2 V2 addition).
 	//
-	// See Data Dictionary, Section 2.167, `VehicleRegistrationNumber`.
+	// Although the regulation specifies VehicleRegistrationNumber (13-byte IA5String),
+	// real VUs write VehicleRegistrationIdentification (15 bytes: nation + codepage + string).
+	// The RecordArray header self-describes the actual record size.
 	//
-	// ASN.1 Definition:
-	//
-	//	VehicleRegistrationNumber ::= IA5String(SIZE(13))
-	VehicleRegistrationNumber *v1.Ia5StringValue
+	// See Data Dictionary, Section 2.166, `VehicleRegistrationIdentification`.
+	VehicleRegistrationIdentification *v1.VehicleRegistrationIdentification
 	// Current date and time of the VU.
 	//
 	// See Data Dictionary, Section 2.54, `CurrentDateTime`.
@@ -475,7 +475,7 @@ func (b0 OverviewGen2V2_builder) Build() *OverviewGen2V2 {
 		x.xxx_hidden_VuCertificate = b.VuCertificate
 	}
 	x.xxx_hidden_VehicleIdentificationNumber = b.VehicleIdentificationNumber
-	x.xxx_hidden_VehicleRegistrationNumber = b.VehicleRegistrationNumber
+	x.xxx_hidden_VehicleRegistrationIdentification = b.VehicleRegistrationIdentification
 	x.xxx_hidden_CurrentDateTime = b.CurrentDateTime
 	x.xxx_hidden_DownloadablePeriod = b.DownloadablePeriod
 	if b.DriverSlotCard != nil {
@@ -1035,12 +1035,12 @@ var File_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto protoreflec
 
 const file_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto_rawDesc = "" +
 	"\n" +
-	";wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a7wayplatform/connect/tachograph/dd/v1/control_type.proto\x1a>wayplatform/connect/tachograph/dd/v1/downloadable_period.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/slot_card_type.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xcf\x13\n" +
+	";wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a7wayplatform/connect/tachograph/dd/v1/control_type.proto\x1a>wayplatform/connect/tachograph/dd/v1/downloadable_period.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/slot_card_type.proto\x1aNwayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xf3\x13\n" +
 	"\x0eOverviewGen2V2\x128\n" +
 	"\x18member_state_certificate\x18\x01 \x01(\fR\x16memberStateCertificate\x12%\n" +
 	"\x0evu_certificate\x18\x02 \x01(\fR\rvuCertificate\x12x\n" +
-	"\x1dvehicle_identification_number\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bvehicleIdentificationNumber\x12t\n" +
-	"\x1bvehicle_registration_number\x18\x04 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x19vehicleRegistrationNumber\x12F\n" +
+	"\x1dvehicle_identification_number\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bvehicleIdentificationNumber\x12\x97\x01\n" +
+	"#vehicle_registration_identification\x18\x04 \x01(\v2G.wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentificationR!vehicleRegistrationIdentification\x12F\n" +
 	"\x11current_date_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0fcurrentDateTime\x12i\n" +
 	"\x13downloadable_period\x18\x06 \x01(\v28.wayplatform.connect.tachograph.dd.v1.DownloadablePeriodR\x12downloadablePeriod\x12\\\n" +
 	"\x10driver_slot_card\x18\a \x01(\x0e22.wayplatform.connect.tachograph.dd.v1.SlotCardTypeR\x0edriverSlotCard\x12a\n" +
@@ -1073,43 +1073,44 @@ const file_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto_rawDesc =
 
 var file_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto_goTypes = []any{
-	(*OverviewGen2V2)(nil),                  // 0: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2
-	(*OverviewGen2V2_DownloadActivity)(nil), // 1: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity
-	(*OverviewGen2V2_CompanyLock)(nil),      // 2: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock
-	(*OverviewGen2V2_ControlActivity)(nil),  // 3: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity
-	(*v1.Ia5StringValue)(nil),               // 4: wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	(*timestamppb.Timestamp)(nil),           // 5: google.protobuf.Timestamp
-	(*v1.DownloadablePeriod)(nil),           // 6: wayplatform.connect.tachograph.dd.v1.DownloadablePeriod
-	(v1.SlotCardType)(0),                    // 7: wayplatform.connect.tachograph.dd.v1.SlotCardType
-	(*v11.Authentication)(nil),              // 8: wayplatform.connect.tachograph.security.v1.Authentication
-	(*v1.FullCardNumberAndGeneration)(nil),  // 9: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	(*v1.StringValue)(nil),                  // 10: wayplatform.connect.tachograph.dd.v1.StringValue
-	(*v1.ControlType)(nil),                  // 11: wayplatform.connect.tachograph.dd.v1.ControlType
+	(*OverviewGen2V2)(nil),                       // 0: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2
+	(*OverviewGen2V2_DownloadActivity)(nil),      // 1: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity
+	(*OverviewGen2V2_CompanyLock)(nil),           // 2: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock
+	(*OverviewGen2V2_ControlActivity)(nil),       // 3: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity
+	(*v1.Ia5StringValue)(nil),                    // 4: wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	(*v1.VehicleRegistrationIdentification)(nil), // 5: wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
+	(*timestamppb.Timestamp)(nil),                // 6: google.protobuf.Timestamp
+	(*v1.DownloadablePeriod)(nil),                // 7: wayplatform.connect.tachograph.dd.v1.DownloadablePeriod
+	(v1.SlotCardType)(0),                         // 8: wayplatform.connect.tachograph.dd.v1.SlotCardType
+	(*v11.Authentication)(nil),                   // 9: wayplatform.connect.tachograph.security.v1.Authentication
+	(*v1.FullCardNumberAndGeneration)(nil),       // 10: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	(*v1.StringValue)(nil),                       // 11: wayplatform.connect.tachograph.dd.v1.StringValue
+	(*v1.ControlType)(nil),                       // 12: wayplatform.connect.tachograph.dd.v1.ControlType
 }
 var file_wayplatform_connect_tachograph_vu_v1_overview_gen2_v2_proto_depIdxs = []int32{
 	4,  // 0: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.vehicle_identification_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	4,  // 1: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.vehicle_registration_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	5,  // 2: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.current_date_time:type_name -> google.protobuf.Timestamp
-	6,  // 3: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.downloadable_period:type_name -> wayplatform.connect.tachograph.dd.v1.DownloadablePeriod
-	7,  // 4: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.driver_slot_card:type_name -> wayplatform.connect.tachograph.dd.v1.SlotCardType
-	7,  // 5: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.co_driver_slot_card:type_name -> wayplatform.connect.tachograph.dd.v1.SlotCardType
+	5,  // 1: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.vehicle_registration_identification:type_name -> wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
+	6,  // 2: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.current_date_time:type_name -> google.protobuf.Timestamp
+	7,  // 3: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.downloadable_period:type_name -> wayplatform.connect.tachograph.dd.v1.DownloadablePeriod
+	8,  // 4: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.driver_slot_card:type_name -> wayplatform.connect.tachograph.dd.v1.SlotCardType
+	8,  // 5: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.co_driver_slot_card:type_name -> wayplatform.connect.tachograph.dd.v1.SlotCardType
 	1,  // 6: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.download_activities:type_name -> wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity
 	2,  // 7: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.company_locks:type_name -> wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock
 	3,  // 8: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.control_activities:type_name -> wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity
-	8,  // 9: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
-	5,  // 10: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.downloading_time:type_name -> google.protobuf.Timestamp
-	9,  // 11: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	10, // 12: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.company_or_workshop_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	5,  // 13: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.lock_in_time:type_name -> google.protobuf.Timestamp
-	5,  // 14: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.lock_out_time:type_name -> google.protobuf.Timestamp
-	10, // 15: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	10, // 16: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	9,  // 17: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	11, // 18: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_type:type_name -> wayplatform.connect.tachograph.dd.v1.ControlType
-	5,  // 19: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_time:type_name -> google.protobuf.Timestamp
-	9,  // 20: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	5,  // 21: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.download_period_begin_time:type_name -> google.protobuf.Timestamp
-	5,  // 22: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.download_period_end_time:type_name -> google.protobuf.Timestamp
+	9,  // 9: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	6,  // 10: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.downloading_time:type_name -> google.protobuf.Timestamp
+	10, // 11: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	11, // 12: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.DownloadActivity.company_or_workshop_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	6,  // 13: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.lock_in_time:type_name -> google.protobuf.Timestamp
+	6,  // 14: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.lock_out_time:type_name -> google.protobuf.Timestamp
+	11, // 15: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	11, // 16: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	10, // 17: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.CompanyLock.company_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	12, // 18: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_type:type_name -> wayplatform.connect.tachograph.dd.v1.ControlType
+	6,  // 19: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_time:type_name -> google.protobuf.Timestamp
+	10, // 20: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.control_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	6,  // 21: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.download_period_begin_time:type_name -> google.protobuf.Timestamp
+	6,  // 22: wayplatform.connect.tachograph.vu.v1.OverviewGen2V2.ControlActivity.download_period_end_time:type_name -> google.protobuf.Timestamp
 	23, // [23:23] is the sub-list for method output_type
 	23, // [23:23] is the sub-list for method input_type
 	23, // [23:23] is the sub-list for extension type_name

--- a/proto/gen/go/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.pb.go
@@ -831,29 +831,36 @@ func (b0 TechnicalDataGen2V2_CoupledGnss_builder) Build() *TechnicalDataGen2V2_C
 //
 // See Data Dictionary, Section 2.174, `VuCalibrationRecord`.
 type TechnicalDataGen2V2_CalibrationRecord struct {
-	state                                      protoimpl.MessageState                 `protogen:"opaque.v1"`
-	xxx_hidden_Purpose                         v11.CalibrationPurpose                 `protobuf:"varint,1,opt,name=purpose,enum=wayplatform.connect.tachograph.dd.v1.CalibrationPurpose"`
-	xxx_hidden_UnrecognizedPurpose             int32                                  `protobuf:"varint,2,opt,name=unrecognized_purpose,json=unrecognizedPurpose"`
-	xxx_hidden_WorkshopName                    *v11.StringValue                       `protobuf:"bytes,3,opt,name=workshop_name,json=workshopName"`
-	xxx_hidden_WorkshopAddress                 *v11.StringValue                       `protobuf:"bytes,4,opt,name=workshop_address,json=workshopAddress"`
-	xxx_hidden_WorkshopCardNumberAndGeneration *v11.FullCardNumberAndGeneration       `protobuf:"bytes,5,opt,name=workshop_card_number_and_generation,json=workshopCardNumberAndGeneration"`
-	xxx_hidden_WorkshopCardExpiryDate          *v11.Date                              `protobuf:"bytes,6,opt,name=workshop_card_expiry_date,json=workshopCardExpiryDate"`
-	xxx_hidden_Vin                             *v11.Ia5StringValue                    `protobuf:"bytes,7,opt,name=vin"`
-	xxx_hidden_VehicleRegistration             *v11.VehicleRegistrationIdentification `protobuf:"bytes,8,opt,name=vehicle_registration,json=vehicleRegistration"`
-	xxx_hidden_WVehicleCharacteristicConstant  int32                                  `protobuf:"varint,9,opt,name=w_vehicle_characteristic_constant,json=wVehicleCharacteristicConstant"`
-	xxx_hidden_KConstantOfRecordingEquipment   int32                                  `protobuf:"varint,10,opt,name=k_constant_of_recording_equipment,json=kConstantOfRecordingEquipment"`
-	xxx_hidden_LTyreCircumferenceEighthsMm     int32                                  `protobuf:"varint,11,opt,name=l_tyre_circumference_eighths_mm,json=lTyreCircumferenceEighthsMm"`
-	xxx_hidden_TyreSize                        *v11.Ia5StringValue                    `protobuf:"bytes,12,opt,name=tyre_size,json=tyreSize"`
-	xxx_hidden_AuthorisedSpeedKmh              int32                                  `protobuf:"varint,13,opt,name=authorised_speed_kmh,json=authorisedSpeedKmh"`
-	xxx_hidden_OldOdometerValueKm              int32                                  `protobuf:"varint,14,opt,name=old_odometer_value_km,json=oldOdometerValueKm"`
-	xxx_hidden_NewOdometerValueKm              int32                                  `protobuf:"varint,15,opt,name=new_odometer_value_km,json=newOdometerValueKm"`
-	xxx_hidden_OldTimeValue                    *timestamppb.Timestamp                 `protobuf:"bytes,16,opt,name=old_time_value,json=oldTimeValue"`
-	xxx_hidden_NewTimeValue                    *timestamppb.Timestamp                 `protobuf:"bytes,17,opt,name=new_time_value,json=newTimeValue"`
-	xxx_hidden_NextCalibrationDate             *timestamppb.Timestamp                 `protobuf:"bytes,18,opt,name=next_calibration_date,json=nextCalibrationDate"`
-	XXX_raceDetectHookData                     protoimpl.RaceDetectHookData
-	XXX_presence                               [1]uint32
-	unknownFields                              protoimpl.UnknownFields
-	sizeCache                                  protoimpl.SizeCache
+	state                                     protoimpl.MessageState                 `protogen:"opaque.v1"`
+	xxx_hidden_Purpose                        v11.CalibrationPurpose                 `protobuf:"varint,1,opt,name=purpose,enum=wayplatform.connect.tachograph.dd.v1.CalibrationPurpose"`
+	xxx_hidden_UnrecognizedPurpose            int32                                  `protobuf:"varint,2,opt,name=unrecognized_purpose,json=unrecognizedPurpose"`
+	xxx_hidden_WorkshopName                   *v11.StringValue                       `protobuf:"bytes,3,opt,name=workshop_name,json=workshopName"`
+	xxx_hidden_WorkshopAddress                *v11.StringValue                       `protobuf:"bytes,4,opt,name=workshop_address,json=workshopAddress"`
+	xxx_hidden_WorkshopCardNumber             *v11.FullCardNumber                    `protobuf:"bytes,5,opt,name=workshop_card_number,json=workshopCardNumber"`
+	xxx_hidden_WorkshopCardExpiryDate         *timestamppb.Timestamp                 `protobuf:"bytes,6,opt,name=workshop_card_expiry_date,json=workshopCardExpiryDate"`
+	xxx_hidden_Vin                            *v11.Ia5StringValue                    `protobuf:"bytes,7,opt,name=vin"`
+	xxx_hidden_VehicleRegistration            *v11.VehicleRegistrationIdentification `protobuf:"bytes,8,opt,name=vehicle_registration,json=vehicleRegistration"`
+	xxx_hidden_WVehicleCharacteristicConstant int32                                  `protobuf:"varint,9,opt,name=w_vehicle_characteristic_constant,json=wVehicleCharacteristicConstant"`
+	xxx_hidden_KConstantOfRecordingEquipment  int32                                  `protobuf:"varint,10,opt,name=k_constant_of_recording_equipment,json=kConstantOfRecordingEquipment"`
+	xxx_hidden_LTyreCircumferenceEighthsMm    int32                                  `protobuf:"varint,11,opt,name=l_tyre_circumference_eighths_mm,json=lTyreCircumferenceEighthsMm"`
+	xxx_hidden_TyreSize                       *v11.Ia5StringValue                    `protobuf:"bytes,12,opt,name=tyre_size,json=tyreSize"`
+	xxx_hidden_AuthorisedSpeedKmh             int32                                  `protobuf:"varint,13,opt,name=authorised_speed_kmh,json=authorisedSpeedKmh"`
+	xxx_hidden_OldOdometerValueKm             int32                                  `protobuf:"varint,14,opt,name=old_odometer_value_km,json=oldOdometerValueKm"`
+	xxx_hidden_NewOdometerValueKm             int32                                  `protobuf:"varint,15,opt,name=new_odometer_value_km,json=newOdometerValueKm"`
+	xxx_hidden_OldTimeValue                   *timestamppb.Timestamp                 `protobuf:"bytes,16,opt,name=old_time_value,json=oldTimeValue"`
+	xxx_hidden_NewTimeValue                   *timestamppb.Timestamp                 `protobuf:"bytes,17,opt,name=new_time_value,json=newTimeValue"`
+	xxx_hidden_NextCalibrationDate            *timestamppb.Timestamp                 `protobuf:"bytes,18,opt,name=next_calibration_date,json=nextCalibrationDate"`
+	xxx_hidden_SensorSerialNumber             *v11.ExtendedSerialNumber              `protobuf:"bytes,19,opt,name=sensor_serial_number,json=sensorSerialNumber"`
+	xxx_hidden_SensorGnssSerialNumber         *v11.ExtendedSerialNumber              `protobuf:"bytes,20,opt,name=sensor_gnss_serial_number,json=sensorGnssSerialNumber"`
+	xxx_hidden_RcmSerialNumber                *v11.ExtendedSerialNumber              `protobuf:"bytes,21,opt,name=rcm_serial_number,json=rcmSerialNumber"`
+	xxx_hidden_SealRecords                    *[]*TechnicalDataGen2V2_SealRecord     `protobuf:"bytes,22,rep,name=seal_records,json=sealRecords"`
+	xxx_hidden_LoadType                       int32                                  `protobuf:"varint,23,opt,name=load_type,json=loadType"`
+	xxx_hidden_CalibrationCountry             v11.NationNumeric                      `protobuf:"varint,24,opt,name=calibration_country,json=calibrationCountry,enum=wayplatform.connect.tachograph.dd.v1.NationNumeric"`
+	xxx_hidden_CalibrationCountryTimestamp    *timestamppb.Timestamp                 `protobuf:"bytes,25,opt,name=calibration_country_timestamp,json=calibrationCountryTimestamp"`
+	XXX_raceDetectHookData                    protoimpl.RaceDetectHookData
+	XXX_presence                              [1]uint32
+	unknownFields                             protoimpl.UnknownFields
+	sizeCache                                 protoimpl.SizeCache
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) Reset() {
@@ -911,14 +918,14 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) GetWorkshopAddress() *v11.String
 	return nil
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) GetWorkshopCardNumberAndGeneration() *v11.FullCardNumberAndGeneration {
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetWorkshopCardNumber() *v11.FullCardNumber {
 	if x != nil {
-		return x.xxx_hidden_WorkshopCardNumberAndGeneration
+		return x.xxx_hidden_WorkshopCardNumber
 	}
 	return nil
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) GetWorkshopCardExpiryDate() *v11.Date {
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetWorkshopCardExpiryDate() *timestamppb.Timestamp {
 	if x != nil {
 		return x.xxx_hidden_WorkshopCardExpiryDate
 	}
@@ -1009,14 +1016,67 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) GetNextCalibrationDate() *timest
 	return nil
 }
 
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetSensorSerialNumber() *v11.ExtendedSerialNumber {
+	if x != nil {
+		return x.xxx_hidden_SensorSerialNumber
+	}
+	return nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetSensorGnssSerialNumber() *v11.ExtendedSerialNumber {
+	if x != nil {
+		return x.xxx_hidden_SensorGnssSerialNumber
+	}
+	return nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetRcmSerialNumber() *v11.ExtendedSerialNumber {
+	if x != nil {
+		return x.xxx_hidden_RcmSerialNumber
+	}
+	return nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetSealRecords() []*TechnicalDataGen2V2_SealRecord {
+	if x != nil {
+		if x.xxx_hidden_SealRecords != nil {
+			return *x.xxx_hidden_SealRecords
+		}
+	}
+	return nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetLoadType() int32 {
+	if x != nil {
+		return x.xxx_hidden_LoadType
+	}
+	return 0
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetCalibrationCountry() v11.NationNumeric {
+	if x != nil {
+		if protoimpl.X.Present(&(x.XXX_presence[0]), 23) {
+			return x.xxx_hidden_CalibrationCountry
+		}
+	}
+	return v11.NationNumeric(0)
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) GetCalibrationCountryTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_CalibrationCountryTimestamp
+	}
+	return nil
+}
+
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetPurpose(v v11.CalibrationPurpose) {
 	x.xxx_hidden_Purpose = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetUnrecognizedPurpose(v int32) {
 	x.xxx_hidden_UnrecognizedPurpose = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopName(v *v11.StringValue) {
@@ -1027,11 +1087,11 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopAddress(v *v11.String
 	x.xxx_hidden_WorkshopAddress = v
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopCardNumberAndGeneration(v *v11.FullCardNumberAndGeneration) {
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = v
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopCardNumber(v *v11.FullCardNumber) {
+	x.xxx_hidden_WorkshopCardNumber = v
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopCardExpiryDate(v *v11.Date) {
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetWorkshopCardExpiryDate(v *timestamppb.Timestamp) {
 	x.xxx_hidden_WorkshopCardExpiryDate = v
 }
 
@@ -1045,17 +1105,17 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) SetVehicleRegistration(v *v11.Ve
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetWVehicleCharacteristicConstant(v int32) {
 	x.xxx_hidden_WVehicleCharacteristicConstant = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 8, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 8, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetKConstantOfRecordingEquipment(v int32) {
 	x.xxx_hidden_KConstantOfRecordingEquipment = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetLTyreCircumferenceEighthsMm(v int32) {
 	x.xxx_hidden_LTyreCircumferenceEighthsMm = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 10, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 10, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetTyreSize(v *v11.Ia5StringValue) {
@@ -1064,17 +1124,17 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) SetTyreSize(v *v11.Ia5StringValu
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetAuthorisedSpeedKmh(v int32) {
 	x.xxx_hidden_AuthorisedSpeedKmh = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 12, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 12, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetOldOdometerValueKm(v int32) {
 	x.xxx_hidden_OldOdometerValueKm = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 13, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 13, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetNewOdometerValueKm(v int32) {
 	x.xxx_hidden_NewOdometerValueKm = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 14, 18)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 14, 25)
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetOldTimeValue(v *timestamppb.Timestamp) {
@@ -1087,6 +1147,36 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) SetNewTimeValue(v *timestamppb.T
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) SetNextCalibrationDate(v *timestamppb.Timestamp) {
 	x.xxx_hidden_NextCalibrationDate = v
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetSensorSerialNumber(v *v11.ExtendedSerialNumber) {
+	x.xxx_hidden_SensorSerialNumber = v
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetSensorGnssSerialNumber(v *v11.ExtendedSerialNumber) {
+	x.xxx_hidden_SensorGnssSerialNumber = v
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetRcmSerialNumber(v *v11.ExtendedSerialNumber) {
+	x.xxx_hidden_RcmSerialNumber = v
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetSealRecords(v []*TechnicalDataGen2V2_SealRecord) {
+	x.xxx_hidden_SealRecords = &v
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetLoadType(v int32) {
+	x.xxx_hidden_LoadType = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 22, 25)
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetCalibrationCountry(v v11.NationNumeric) {
+	x.xxx_hidden_CalibrationCountry = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 23, 25)
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) SetCalibrationCountryTimestamp(v *timestamppb.Timestamp) {
+	x.xxx_hidden_CalibrationCountryTimestamp = v
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) HasPurpose() bool {
@@ -1117,11 +1207,11 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) HasWorkshopAddress() bool {
 	return x.xxx_hidden_WorkshopAddress != nil
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) HasWorkshopCardNumberAndGeneration() bool {
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasWorkshopCardNumber() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_WorkshopCardNumberAndGeneration != nil
+	return x.xxx_hidden_WorkshopCardNumber != nil
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) HasWorkshopCardExpiryDate() bool {
@@ -1215,6 +1305,48 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) HasNextCalibrationDate() bool {
 	return x.xxx_hidden_NextCalibrationDate != nil
 }
 
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasSensorSerialNumber() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_SensorSerialNumber != nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasSensorGnssSerialNumber() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_SensorGnssSerialNumber != nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasRcmSerialNumber() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RcmSerialNumber != nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasLoadType() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 22)
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasCalibrationCountry() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 23)
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) HasCalibrationCountryTimestamp() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_CalibrationCountryTimestamp != nil
+}
+
 func (x *TechnicalDataGen2V2_CalibrationRecord) ClearPurpose() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
 	x.xxx_hidden_Purpose = v11.CalibrationPurpose_CALIBRATION_PURPOSE_UNSPECIFIED
@@ -1233,8 +1365,8 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) ClearWorkshopAddress() {
 	x.xxx_hidden_WorkshopAddress = nil
 }
 
-func (x *TechnicalDataGen2V2_CalibrationRecord) ClearWorkshopCardNumberAndGeneration() {
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = nil
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearWorkshopCardNumber() {
+	x.xxx_hidden_WorkshopCardNumber = nil
 }
 
 func (x *TechnicalDataGen2V2_CalibrationRecord) ClearWorkshopCardExpiryDate() {
@@ -1295,6 +1427,32 @@ func (x *TechnicalDataGen2V2_CalibrationRecord) ClearNextCalibrationDate() {
 	x.xxx_hidden_NextCalibrationDate = nil
 }
 
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearSensorSerialNumber() {
+	x.xxx_hidden_SensorSerialNumber = nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearSensorGnssSerialNumber() {
+	x.xxx_hidden_SensorGnssSerialNumber = nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearRcmSerialNumber() {
+	x.xxx_hidden_RcmSerialNumber = nil
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearLoadType() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 22)
+	x.xxx_hidden_LoadType = 0
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearCalibrationCountry() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 23)
+	x.xxx_hidden_CalibrationCountry = v11.NationNumeric_NATION_NUMERIC_UNSPECIFIED
+}
+
+func (x *TechnicalDataGen2V2_CalibrationRecord) ClearCalibrationCountryTimestamp() {
+	x.xxx_hidden_CalibrationCountryTimestamp = nil
+}
+
 type TechnicalDataGen2V2_CalibrationRecord_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -1311,14 +1469,14 @@ type TechnicalDataGen2V2_CalibrationRecord_builder struct {
 	//
 	// See Data Dictionary, Section 2.2, `Address`.
 	WorkshopAddress *v11.StringValue
-	// The card number and generation of the workshop.
+	// The card number of the workshop.
 	//
-	// See Data Dictionary, Section 2.74, `FullCardNumberAndGeneration`.
-	WorkshopCardNumberAndGeneration *v11.FullCardNumberAndGeneration
+	// See Data Dictionary, Section 2.73, `FullCardNumber`.
+	WorkshopCardNumber *v11.FullCardNumber
 	// The expiry date of the workshop card.
 	//
-	// See Data Dictionary, Section 2.57, `Datef`.
-	WorkshopCardExpiryDate *v11.Date
+	// See Data Dictionary, Section 2.162, `TimeReal`.
+	WorkshopCardExpiryDate *timestamppb.Timestamp
 	// The Vehicle Identification Number.
 	//
 	// See Data Dictionary, Section 2.164, `VehicleIdentificationNumber`.
@@ -1367,6 +1525,24 @@ type TechnicalDataGen2V2_CalibrationRecord_builder struct {
 	//
 	// See Data Dictionary, Section 2.162, `TimeReal`.
 	NextCalibrationDate *timestamppb.Timestamp
+	// The serial number of the motion sensor at calibration time.
+	SensorSerialNumber *v11.ExtendedSerialNumber
+	// The serial number of the GNSS facility at calibration time.
+	SensorGnssSerialNumber *v11.ExtendedSerialNumber
+	// The serial number of the remote communication module at calibration time.
+	RcmSerialNumber *v11.ExtendedSerialNumber
+	// Seal records. Fixed array of 5 SealRecords.
+	SealRecords []*TechnicalDataGen2V2_SealRecord
+	// The default load type.
+	//
+	// See Data Dictionary, Section 2.92, `LoadType`.
+	LoadType *int32
+	// The nation where calibration was performed.
+	//
+	// See Data Dictionary, Section 2.100, `NationNumeric`.
+	CalibrationCountry *v11.NationNumeric
+	// The timestamp of the calibration country setting.
+	CalibrationCountryTimestamp *timestamppb.Timestamp
 }
 
 func (b0 TechnicalDataGen2V2_CalibrationRecord_builder) Build() *TechnicalDataGen2V2_CalibrationRecord {
@@ -1374,47 +1550,237 @@ func (b0 TechnicalDataGen2V2_CalibrationRecord_builder) Build() *TechnicalDataGe
 	b, x := &b0, m0
 	_, _ = b, x
 	if b.Purpose != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 25)
 		x.xxx_hidden_Purpose = *b.Purpose
 	}
 	if b.UnrecognizedPurpose != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 25)
 		x.xxx_hidden_UnrecognizedPurpose = *b.UnrecognizedPurpose
 	}
 	x.xxx_hidden_WorkshopName = b.WorkshopName
 	x.xxx_hidden_WorkshopAddress = b.WorkshopAddress
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = b.WorkshopCardNumberAndGeneration
+	x.xxx_hidden_WorkshopCardNumber = b.WorkshopCardNumber
 	x.xxx_hidden_WorkshopCardExpiryDate = b.WorkshopCardExpiryDate
 	x.xxx_hidden_Vin = b.Vin
 	x.xxx_hidden_VehicleRegistration = b.VehicleRegistration
 	if b.WVehicleCharacteristicConstant != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 8, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 8, 25)
 		x.xxx_hidden_WVehicleCharacteristicConstant = *b.WVehicleCharacteristicConstant
 	}
 	if b.KConstantOfRecordingEquipment != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 25)
 		x.xxx_hidden_KConstantOfRecordingEquipment = *b.KConstantOfRecordingEquipment
 	}
 	if b.LTyreCircumferenceEighthsMm != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 10, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 10, 25)
 		x.xxx_hidden_LTyreCircumferenceEighthsMm = *b.LTyreCircumferenceEighthsMm
 	}
 	x.xxx_hidden_TyreSize = b.TyreSize
 	if b.AuthorisedSpeedKmh != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 12, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 12, 25)
 		x.xxx_hidden_AuthorisedSpeedKmh = *b.AuthorisedSpeedKmh
 	}
 	if b.OldOdometerValueKm != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 13, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 13, 25)
 		x.xxx_hidden_OldOdometerValueKm = *b.OldOdometerValueKm
 	}
 	if b.NewOdometerValueKm != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 14, 18)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 14, 25)
 		x.xxx_hidden_NewOdometerValueKm = *b.NewOdometerValueKm
 	}
 	x.xxx_hidden_OldTimeValue = b.OldTimeValue
 	x.xxx_hidden_NewTimeValue = b.NewTimeValue
 	x.xxx_hidden_NextCalibrationDate = b.NextCalibrationDate
+	x.xxx_hidden_SensorSerialNumber = b.SensorSerialNumber
+	x.xxx_hidden_SensorGnssSerialNumber = b.SensorGnssSerialNumber
+	x.xxx_hidden_RcmSerialNumber = b.RcmSerialNumber
+	x.xxx_hidden_SealRecords = &b.SealRecords
+	if b.LoadType != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 22, 25)
+		x.xxx_hidden_LoadType = *b.LoadType
+	}
+	if b.CalibrationCountry != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 23, 25)
+		x.xxx_hidden_CalibrationCountry = *b.CalibrationCountry
+	}
+	x.xxx_hidden_CalibrationCountryTimestamp = b.CalibrationCountryTimestamp
+	return m0
+}
+
+// A seal record from the SealDataVu structure.
+type TechnicalDataGen2V2_SealRecord struct {
+	state                                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_EquipmentType             v11.EquipmentType      `protobuf:"varint,1,opt,name=equipment_type,json=equipmentType,enum=wayplatform.connect.tachograph.dd.v1.EquipmentType"`
+	xxx_hidden_UnrecognizedEquipmentType int32                  `protobuf:"varint,2,opt,name=unrecognized_equipment_type,json=unrecognizedEquipmentType"`
+	xxx_hidden_ManufacturerCode          *string                `protobuf:"bytes,3,opt,name=manufacturer_code,json=manufacturerCode"`
+	xxx_hidden_SealIdentifier            *string                `protobuf:"bytes,4,opt,name=seal_identifier,json=sealIdentifier"`
+	XXX_raceDetectHookData               protoimpl.RaceDetectHookData
+	XXX_presence                         [1]uint32
+	unknownFields                        protoimpl.UnknownFields
+	sizeCache                            protoimpl.SizeCache
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) Reset() {
+	*x = TechnicalDataGen2V2_SealRecord{}
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TechnicalDataGen2V2_SealRecord) ProtoMessage() {}
+
+func (x *TechnicalDataGen2V2_SealRecord) ProtoReflect() protoreflect.Message {
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) GetEquipmentType() v11.EquipmentType {
+	if x != nil {
+		if protoimpl.X.Present(&(x.XXX_presence[0]), 0) {
+			return x.xxx_hidden_EquipmentType
+		}
+	}
+	return v11.EquipmentType(0)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) GetUnrecognizedEquipmentType() int32 {
+	if x != nil {
+		return x.xxx_hidden_UnrecognizedEquipmentType
+	}
+	return 0
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) GetManufacturerCode() string {
+	if x != nil {
+		if x.xxx_hidden_ManufacturerCode != nil {
+			return *x.xxx_hidden_ManufacturerCode
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) GetSealIdentifier() string {
+	if x != nil {
+		if x.xxx_hidden_SealIdentifier != nil {
+			return *x.xxx_hidden_SealIdentifier
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) SetEquipmentType(v v11.EquipmentType) {
+	x.xxx_hidden_EquipmentType = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 4)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) SetUnrecognizedEquipmentType(v int32) {
+	x.xxx_hidden_UnrecognizedEquipmentType = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 4)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) SetManufacturerCode(v string) {
+	x.xxx_hidden_ManufacturerCode = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 4)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) SetSealIdentifier(v string) {
+	x.xxx_hidden_SealIdentifier = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 4)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) HasEquipmentType() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) HasUnrecognizedEquipmentType() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) HasManufacturerCode() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) HasSealIdentifier() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 3)
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) ClearEquipmentType() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_EquipmentType = v11.EquipmentType_EQUIPMENT_TYPE_UNSPECIFIED
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) ClearUnrecognizedEquipmentType() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_UnrecognizedEquipmentType = 0
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) ClearManufacturerCode() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	x.xxx_hidden_ManufacturerCode = nil
+}
+
+func (x *TechnicalDataGen2V2_SealRecord) ClearSealIdentifier() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
+	x.xxx_hidden_SealIdentifier = nil
+}
+
+type TechnicalDataGen2V2_SealRecord_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The type of equipment this seal applies to.
+	EquipmentType             *v11.EquipmentType
+	UnrecognizedEquipmentType *int32
+	// The manufacturer code (2-byte IA5String).
+	ManufacturerCode *string
+	// The seal identifier (8-byte IA5String).
+	SealIdentifier *string
+}
+
+func (b0 TechnicalDataGen2V2_SealRecord_builder) Build() *TechnicalDataGen2V2_SealRecord {
+	m0 := &TechnicalDataGen2V2_SealRecord{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.EquipmentType != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 4)
+		x.xxx_hidden_EquipmentType = *b.EquipmentType
+	}
+	if b.UnrecognizedEquipmentType != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 4)
+		x.xxx_hidden_UnrecognizedEquipmentType = *b.UnrecognizedEquipmentType
+	}
+	if b.ManufacturerCode != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 4)
+		x.xxx_hidden_ManufacturerCode = b.ManufacturerCode
+	}
+	if b.SealIdentifier != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 4)
+		x.xxx_hidden_SealIdentifier = b.SealIdentifier
+	}
 	return m0
 }
 
@@ -1434,7 +1800,7 @@ type TechnicalDataGen2V2_CardRecord struct {
 
 func (x *TechnicalDataGen2V2_CardRecord) Reset() {
 	*x = TechnicalDataGen2V2_CardRecord{}
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[5]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1446,7 +1812,7 @@ func (x *TechnicalDataGen2V2_CardRecord) String() string {
 func (*TechnicalDataGen2V2_CardRecord) ProtoMessage() {}
 
 func (x *TechnicalDataGen2V2_CardRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[5]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1616,7 +1982,7 @@ type TechnicalDataGen2V2_ItsConsentRecord struct {
 
 func (x *TechnicalDataGen2V2_ItsConsentRecord) Reset() {
 	*x = TechnicalDataGen2V2_ItsConsentRecord{}
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[6]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1628,7 +1994,7 @@ func (x *TechnicalDataGen2V2_ItsConsentRecord) String() string {
 func (*TechnicalDataGen2V2_ItsConsentRecord) ProtoMessage() {}
 
 func (x *TechnicalDataGen2V2_ItsConsentRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[6]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1722,7 +2088,7 @@ type TechnicalDataGen2V2_PowerSupplyInterruptionRecord struct {
 
 func (x *TechnicalDataGen2V2_PowerSupplyInterruptionRecord) Reset() {
 	*x = TechnicalDataGen2V2_PowerSupplyInterruptionRecord{}
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[7]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1734,7 +2100,7 @@ func (x *TechnicalDataGen2V2_PowerSupplyInterruptionRecord) String() string {
 func (*TechnicalDataGen2V2_PowerSupplyInterruptionRecord) ProtoMessage() {}
 
 func (x *TechnicalDataGen2V2_PowerSupplyInterruptionRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[7]
+	mi := &file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1851,7 +2217,7 @@ var File_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto proto
 
 const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_rawDesc = "" +
 	"\n" +
-	"Awayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a>wayplatform/connect/tachograph/dd/v1/calibration_purpose.proto\x1a;wayplatform/connect/tachograph/dd/v1/card_slot_number.proto\x1aAwayplatform/connect/tachograph/dd/v1/card_structure_version.proto\x1a/wayplatform/connect/tachograph/dd/v1/date.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1aBwayplatform/connect/tachograph/dd/v1/software_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1aNwayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xb3%\n" +
+	"Awayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a>wayplatform/connect/tachograph/dd/v1/calibration_purpose.proto\x1a;wayplatform/connect/tachograph/dd/v1/card_slot_number.proto\x1aAwayplatform/connect/tachograph/dd/v1/card_structure_version.proto\x1a/wayplatform/connect/tachograph/dd/v1/date.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1a9wayplatform/connect/tachograph/dd/v1/equipment_type.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1a;wayplatform/connect/tachograph/dd/v1/full_card_number.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1aBwayplatform/connect/tachograph/dd/v1/software_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1aNwayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\x93,\n" +
 	"\x13TechnicalDataGen2V2\x12w\n" +
 	"\x11vu_identification\x18\x01 \x01(\v2J.wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentificationR\x10vuIdentification\x12|\n" +
 	"\x13calibration_records\x18\x02 \x03(\v2K.wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecordR\x12calibrationRecords\x12m\n" +
@@ -1879,14 +2245,14 @@ const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_raw
 	"\vCoupledGnss\x12_\n" +
 	"\rserial_number\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumberR\fserialNumber\x12]\n" +
 	"\x0fapproval_number\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x0eapprovalNumber\x12?\n" +
-	"\rcoupling_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\fcouplingDate\x1a\xa7\v\n" +
+	"\rcoupling_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\fcouplingDate\x1a\x86\x10\n" +
 	"\x11CalibrationRecord\x12R\n" +
 	"\apurpose\x18\x01 \x01(\x0e28.wayplatform.connect.tachograph.dd.v1.CalibrationPurposeR\apurpose\x121\n" +
 	"\x14unrecognized_purpose\x18\x02 \x01(\x05R\x13unrecognizedPurpose\x12V\n" +
 	"\rworkshop_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\fworkshopName\x12\\\n" +
-	"\x10workshop_address\x18\x04 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fworkshopAddress\x12\x8f\x01\n" +
-	"#workshop_card_number_and_generation\x18\x05 \x01(\v2A.wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGenerationR\x1fworkshopCardNumberAndGeneration\x12e\n" +
-	"\x19workshop_card_expiry_date\x18\x06 \x01(\v2*.wayplatform.connect.tachograph.dd.v1.DateR\x16workshopCardExpiryDate\x12F\n" +
+	"\x10workshop_address\x18\x04 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fworkshopAddress\x12f\n" +
+	"\x14workshop_card_number\x18\x05 \x01(\v24.wayplatform.connect.tachograph.dd.v1.FullCardNumberR\x12workshopCardNumber\x12U\n" +
+	"\x19workshop_card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x16workshopCardExpiryDate\x12F\n" +
 	"\x03vin\x18\a \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x03vin\x12z\n" +
 	"\x14vehicle_registration\x18\b \x01(\v2G.wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentificationR\x13vehicleRegistration\x12I\n" +
 	"!w_vehicle_characteristic_constant\x18\t \x01(\x05R\x1ewVehicleCharacteristicConstant\x12H\n" +
@@ -1899,7 +2265,20 @@ const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_raw
 	"\x15new_odometer_value_km\x18\x0f \x01(\x05R\x12newOdometerValueKm\x12@\n" +
 	"\x0eold_time_value\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\foldTimeValue\x12@\n" +
 	"\x0enew_time_value\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\fnewTimeValue\x12N\n" +
-	"\x15next_calibration_date\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\x13nextCalibrationDate\x1a\xd8\x04\n" +
+	"\x15next_calibration_date\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\x13nextCalibrationDate\x12l\n" +
+	"\x14sensor_serial_number\x18\x13 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumberR\x12sensorSerialNumber\x12u\n" +
+	"\x19sensor_gnss_serial_number\x18\x14 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumberR\x16sensorGnssSerialNumber\x12f\n" +
+	"\x11rcm_serial_number\x18\x15 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumberR\x0frcmSerialNumber\x12g\n" +
+	"\fseal_records\x18\x16 \x03(\v2D.wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.SealRecordR\vsealRecords\x12\x1b\n" +
+	"\tload_type\x18\x17 \x01(\x05R\bloadType\x12d\n" +
+	"\x13calibration_country\x18\x18 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x12calibrationCountry\x12^\n" +
+	"\x1dcalibration_country_timestamp\x18\x19 \x01(\v2\x1a.google.protobuf.TimestampR\x1bcalibrationCountryTimestamp\x1a\xfe\x01\n" +
+	"\n" +
+	"SealRecord\x12Z\n" +
+	"\x0eequipment_type\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.EquipmentTypeR\requipmentType\x12>\n" +
+	"\x1bunrecognized_equipment_type\x18\x02 \x01(\x05R\x19unrecognizedEquipmentType\x12+\n" +
+	"\x11manufacturer_code\x18\x03 \x01(\tR\x10manufacturerCode\x12'\n" +
+	"\x0fseal_identifier\x18\x04 \x01(\tR\x0esealIdentifier\x1a\xd8\x04\n" +
 	"\n" +
 	"CardRecord\x12~\n" +
 	"\x1acard_number_and_generation\x18\x01 \x01(\v2A.wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGenerationR\x17cardNumberAndGeneration\x12y\n" +
@@ -1916,77 +2295,87 @@ const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_raw
 	"\x1dunrecognized_card_slot_number\x18\x03 \x01(\x05R\x1aunrecognizedCardSlotNumberB\xd7\x02\n" +
 	"(com.wayplatform.connect.tachograph.vu.v1B\x18TechnicalDataGen2V2ProtoP\x01Z\\github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/vu/v1;vuv1\xa2\x02\x04WCTV\xaa\x02$Wayplatform.Connect.Tachograph.Vu.V1\xca\x02$Wayplatform\\Connect\\Tachograph\\Vu\\V1\xe2\x020Wayplatform\\Connect\\Tachograph\\Vu\\V1\\GPBMetadata\xea\x02(Wayplatform::Connect::Tachograph::Vu::V1b\beditionsp\xe8\a"
 
-var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_goTypes = []any{
 	(*TechnicalDataGen2V2)(nil),                               // 0: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2
 	(*TechnicalDataGen2V2_VuIdentification)(nil),              // 1: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification
 	(*TechnicalDataGen2V2_PairedSensor)(nil),                  // 2: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor
 	(*TechnicalDataGen2V2_CoupledGnss)(nil),                   // 3: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss
 	(*TechnicalDataGen2V2_CalibrationRecord)(nil),             // 4: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord
-	(*TechnicalDataGen2V2_CardRecord)(nil),                    // 5: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord
-	(*TechnicalDataGen2V2_ItsConsentRecord)(nil),              // 6: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord
-	(*TechnicalDataGen2V2_PowerSupplyInterruptionRecord)(nil), // 7: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord
-	(*v1.Authentication)(nil),                                 // 8: wayplatform.connect.tachograph.security.v1.Authentication
-	(*v11.StringValue)(nil),                                   // 9: wayplatform.connect.tachograph.dd.v1.StringValue
-	(*v11.Ia5StringValue)(nil),                                // 10: wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	(*v11.ExtendedSerialNumber)(nil),                          // 11: wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
-	(*v11.SoftwareIdentification)(nil),                        // 12: wayplatform.connect.tachograph.dd.v1.SoftwareIdentification
-	(*timestamppb.Timestamp)(nil),                             // 13: google.protobuf.Timestamp
-	(v11.CalibrationPurpose)(0),                               // 14: wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
-	(*v11.FullCardNumberAndGeneration)(nil),                   // 15: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	(*v11.Date)(nil),                                          // 16: wayplatform.connect.tachograph.dd.v1.Date
+	(*TechnicalDataGen2V2_SealRecord)(nil),                    // 5: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.SealRecord
+	(*TechnicalDataGen2V2_CardRecord)(nil),                    // 6: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord
+	(*TechnicalDataGen2V2_ItsConsentRecord)(nil),              // 7: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord
+	(*TechnicalDataGen2V2_PowerSupplyInterruptionRecord)(nil), // 8: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord
+	(*v1.Authentication)(nil),                                 // 9: wayplatform.connect.tachograph.security.v1.Authentication
+	(*v11.StringValue)(nil),                                   // 10: wayplatform.connect.tachograph.dd.v1.StringValue
+	(*v11.Ia5StringValue)(nil),                                // 11: wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	(*v11.ExtendedSerialNumber)(nil),                          // 12: wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	(*v11.SoftwareIdentification)(nil),                        // 13: wayplatform.connect.tachograph.dd.v1.SoftwareIdentification
+	(*timestamppb.Timestamp)(nil),                             // 14: google.protobuf.Timestamp
+	(v11.CalibrationPurpose)(0),                               // 15: wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
+	(*v11.FullCardNumber)(nil),                                // 16: wayplatform.connect.tachograph.dd.v1.FullCardNumber
 	(*v11.VehicleRegistrationIdentification)(nil),             // 17: wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
-	(*v11.CardStructureVersion)(nil),                          // 18: wayplatform.connect.tachograph.dd.v1.CardStructureVersion
-	(*v11.DriverIdentification)(nil),                          // 19: wayplatform.connect.tachograph.dd.v1.DriverIdentification
-	(*v11.OwnerIdentification)(nil),                           // 20: wayplatform.connect.tachograph.dd.v1.OwnerIdentification
-	(v11.CardSlotNumber)(0),                                   // 21: wayplatform.connect.tachograph.dd.v1.CardSlotNumber
+	(v11.NationNumeric)(0),                                    // 18: wayplatform.connect.tachograph.dd.v1.NationNumeric
+	(v11.EquipmentType)(0),                                    // 19: wayplatform.connect.tachograph.dd.v1.EquipmentType
+	(*v11.FullCardNumberAndGeneration)(nil),                   // 20: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	(*v11.CardStructureVersion)(nil),                          // 21: wayplatform.connect.tachograph.dd.v1.CardStructureVersion
+	(*v11.DriverIdentification)(nil),                          // 22: wayplatform.connect.tachograph.dd.v1.DriverIdentification
+	(*v11.OwnerIdentification)(nil),                           // 23: wayplatform.connect.tachograph.dd.v1.OwnerIdentification
+	(v11.CardSlotNumber)(0),                                   // 24: wayplatform.connect.tachograph.dd.v1.CardSlotNumber
 }
 var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_depIdxs = []int32{
 	1,  // 0: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.vu_identification:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification
 	4,  // 1: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.calibration_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord
 	2,  // 2: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.paired_sensors:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor
 	3,  // 3: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.coupled_gnss_facilities:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss
-	5,  // 4: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.card_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord
-	6,  // 5: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.its_consent_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord
-	7,  // 6: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.power_supply_interruptions:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord
-	8,  // 7: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
-	9,  // 8: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturer_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	9,  // 9: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturer_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	10, // 10: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.part_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	11, // 11: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
-	12, // 12: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.software_identification:type_name -> wayplatform.connect.tachograph.dd.v1.SoftwareIdentification
-	13, // 13: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturing_date:type_name -> google.protobuf.Timestamp
-	10, // 14: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	11, // 15: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
-	10, // 16: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	13, // 17: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.pairing_date:type_name -> google.protobuf.Timestamp
-	11, // 18: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
-	10, // 19: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	13, // 20: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.coupling_date:type_name -> google.protobuf.Timestamp
-	14, // 21: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.purpose:type_name -> wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
-	9,  // 22: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	9,  // 23: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	15, // 24: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	16, // 25: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_card_expiry_date:type_name -> wayplatform.connect.tachograph.dd.v1.Date
-	10, // 26: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.vin:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	6,  // 4: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.card_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord
+	7,  // 5: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.its_consent_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord
+	8,  // 6: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.power_supply_interruptions:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord
+	9,  // 7: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.authentication:type_name -> wayplatform.connect.tachograph.security.v1.Authentication
+	10, // 8: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturer_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	10, // 9: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturer_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	11, // 10: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.part_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	12, // 11: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	13, // 12: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.software_identification:type_name -> wayplatform.connect.tachograph.dd.v1.SoftwareIdentification
+	14, // 13: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.manufacturing_date:type_name -> google.protobuf.Timestamp
+	11, // 14: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.VuIdentification.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	12, // 15: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	11, // 16: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	14, // 17: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PairedSensor.pairing_date:type_name -> google.protobuf.Timestamp
+	12, // 18: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	11, // 19: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.approval_number:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	14, // 20: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CoupledGnss.coupling_date:type_name -> google.protobuf.Timestamp
+	15, // 21: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.purpose:type_name -> wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
+	10, // 22: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	10, // 23: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
+	16, // 24: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_card_number:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumber
+	14, // 25: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.workshop_card_expiry_date:type_name -> google.protobuf.Timestamp
+	11, // 26: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.vin:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
 	17, // 27: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.vehicle_registration:type_name -> wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
-	10, // 28: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.tyre_size:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	13, // 29: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.old_time_value:type_name -> google.protobuf.Timestamp
-	13, // 30: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.new_time_value:type_name -> google.protobuf.Timestamp
-	13, // 31: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.next_calibration_date:type_name -> google.protobuf.Timestamp
-	15, // 32: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	11, // 33: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_extended_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
-	18, // 34: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_structure_version:type_name -> wayplatform.connect.tachograph.dd.v1.CardStructureVersion
-	19, // 35: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.driver_identification:type_name -> wayplatform.connect.tachograph.dd.v1.DriverIdentification
-	20, // 36: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.owner_identification:type_name -> wayplatform.connect.tachograph.dd.v1.OwnerIdentification
-	15, // 37: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	13, // 38: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord.timestamp:type_name -> google.protobuf.Timestamp
-	21, // 39: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord.card_slot_number:type_name -> wayplatform.connect.tachograph.dd.v1.CardSlotNumber
-	40, // [40:40] is the sub-list for method output_type
-	40, // [40:40] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	11, // 28: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.tyre_size:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
+	14, // 29: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.old_time_value:type_name -> google.protobuf.Timestamp
+	14, // 30: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.new_time_value:type_name -> google.protobuf.Timestamp
+	14, // 31: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.next_calibration_date:type_name -> google.protobuf.Timestamp
+	12, // 32: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.sensor_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	12, // 33: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.sensor_gnss_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	12, // 34: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.rcm_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	5,  // 35: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.seal_records:type_name -> wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.SealRecord
+	18, // 36: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.calibration_country:type_name -> wayplatform.connect.tachograph.dd.v1.NationNumeric
+	14, // 37: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CalibrationRecord.calibration_country_timestamp:type_name -> google.protobuf.Timestamp
+	19, // 38: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.SealRecord.equipment_type:type_name -> wayplatform.connect.tachograph.dd.v1.EquipmentType
+	20, // 39: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	12, // 40: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_extended_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
+	21, // 41: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.card_structure_version:type_name -> wayplatform.connect.tachograph.dd.v1.CardStructureVersion
+	22, // 42: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.driver_identification:type_name -> wayplatform.connect.tachograph.dd.v1.DriverIdentification
+	23, // 43: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.CardRecord.owner_identification:type_name -> wayplatform.connect.tachograph.dd.v1.OwnerIdentification
+	20, // 44: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.ItsConsentRecord.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	14, // 45: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord.timestamp:type_name -> google.protobuf.Timestamp
+	24, // 46: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V2.PowerSupplyInterruptionRecord.card_slot_number:type_name -> wayplatform.connect.tachograph.dd.v1.CardSlotNumber
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_init() }
@@ -2000,7 +2389,7 @@ func file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_init
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_rawDesc), len(file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v2_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.proto
+++ b/proto/wayplatform/connect/tachograph/vu/v1/overview_gen2_v2.proto
@@ -8,6 +8,7 @@ import "wayplatform/connect/tachograph/dd/v1/downloadable_period.proto";
 import "wayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto";
 import "wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto";
 import "wayplatform/connect/tachograph/dd/v1/slot_card_type.proto";
+import "wayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto";
 import "wayplatform/connect/tachograph/dd/v1/string_value.proto";
 import "wayplatform/connect/tachograph/security/v1/authentication.proto";
 
@@ -160,14 +161,14 @@ message OverviewGen2V2 {
   //     VehicleIdentificationNumber ::= IA5String(SIZE(17))
   wayplatform.connect.tachograph.dd.v1.Ia5StringValue vehicle_identification_number = 3;
 
-  // The vehicle registration number only (Gen2 V2 addition).
+  // The vehicle registration identification (Gen2 V2 addition).
   //
-  // See Data Dictionary, Section 2.167, `VehicleRegistrationNumber`.
+  // Although the regulation specifies VehicleRegistrationNumber (13-byte IA5String),
+  // real VUs write VehicleRegistrationIdentification (15 bytes: nation + codepage + string).
+  // The RecordArray header self-describes the actual record size.
   //
-  // ASN.1 Definition:
-  //
-  //     VehicleRegistrationNumber ::= IA5String(SIZE(13))
-  wayplatform.connect.tachograph.dd.v1.Ia5StringValue vehicle_registration_number = 4;
+  // See Data Dictionary, Section 2.166, `VehicleRegistrationIdentification`.
+  wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification vehicle_registration_identification = 4;
 
   // Current date and time of the VU.
   //

--- a/proto/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.proto
+++ b/proto/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v2.proto
@@ -8,8 +8,11 @@ import "wayplatform/connect/tachograph/dd/v1/card_slot_number.proto";
 import "wayplatform/connect/tachograph/dd/v1/card_structure_version.proto";
 import "wayplatform/connect/tachograph/dd/v1/date.proto";
 import "wayplatform/connect/tachograph/dd/v1/driver_identification.proto";
+import "wayplatform/connect/tachograph/dd/v1/equipment_type.proto";
 import "wayplatform/connect/tachograph/dd/v1/extended_serial_number.proto";
+import "wayplatform/connect/tachograph/dd/v1/full_card_number.proto";
 import "wayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto";
+import "wayplatform/connect/tachograph/dd/v1/nation_numeric.proto";
 import "wayplatform/connect/tachograph/dd/v1/owner_identification.proto";
 import "wayplatform/connect/tachograph/dd/v1/software_identification.proto";
 import "wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto";
@@ -134,15 +137,15 @@ message TechnicalDataGen2V2 {
     // See Data Dictionary, Section 2.2, `Address`.
     wayplatform.connect.tachograph.dd.v1.StringValue workshop_address = 4;
 
-    // The card number and generation of the workshop.
+    // The card number of the workshop.
     //
-    // See Data Dictionary, Section 2.74, `FullCardNumberAndGeneration`.
-    dd.v1.FullCardNumberAndGeneration workshop_card_number_and_generation = 5;
+    // See Data Dictionary, Section 2.73, `FullCardNumber`.
+    dd.v1.FullCardNumber workshop_card_number = 5;
 
     // The expiry date of the workshop card.
     //
-    // See Data Dictionary, Section 2.57, `Datef`.
-    wayplatform.connect.tachograph.dd.v1.Date workshop_card_expiry_date = 6;
+    // See Data Dictionary, Section 2.162, `TimeReal`.
+    google.protobuf.Timestamp workshop_card_expiry_date = 6;
 
     // The Vehicle Identification Number.
     //
@@ -203,6 +206,46 @@ message TechnicalDataGen2V2 {
     //
     // See Data Dictionary, Section 2.162, `TimeReal`.
     google.protobuf.Timestamp next_calibration_date = 18;
+
+    // V2 extension fields:
+
+    // The serial number of the motion sensor at calibration time.
+    dd.v1.ExtendedSerialNumber sensor_serial_number = 19;
+
+    // The serial number of the GNSS facility at calibration time.
+    dd.v1.ExtendedSerialNumber sensor_gnss_serial_number = 20;
+
+    // The serial number of the remote communication module at calibration time.
+    dd.v1.ExtendedSerialNumber rcm_serial_number = 21;
+
+    // Seal records. Fixed array of 5 SealRecords.
+    repeated SealRecord seal_records = 22;
+
+    // The default load type.
+    //
+    // See Data Dictionary, Section 2.92, `LoadType`.
+    int32 load_type = 23;
+
+    // The nation where calibration was performed.
+    //
+    // See Data Dictionary, Section 2.100, `NationNumeric`.
+    dd.v1.NationNumeric calibration_country = 24;
+
+    // The timestamp of the calibration country setting.
+    google.protobuf.Timestamp calibration_country_timestamp = 25;
+  }
+
+  // A seal record from the SealDataVu structure.
+  message SealRecord {
+    // The type of equipment this seal applies to.
+    dd.v1.EquipmentType equipment_type = 1;
+    int32 unrecognized_equipment_type = 2;
+
+    // The manufacturer code (2-byte IA5String).
+    string manufacturer_code = 3;
+
+    // The seal identifier (8-byte IA5String).
+    string seal_identifier = 4;
   }
 
   // Represents a record of a card used in the VU.


### PR DESCRIPTION
## Summary

- **Overview Gen2 V2 VRN**: parse `VehicleRegistrationIdentification` (15 bytes: nation + codepage + string) instead of `Ia5StringValue` (13 bytes), eliminating `\u0012\u000f` control char prefixes in VRN fields
- **Technical Data Gen2 V2 calibration records**: add dedicated 252-byte parser with correct V2 layout (`FullCardNumber`(18), `TimeReal` expiry, V2 extension fields); fall back to V1 168-byte parser for VUs that send V1-layout records
- **IA5String control chars**: trim all ASCII control characters (0x00-0x1F) from string fields, eliminating `\u00xx` escape sequences in JSON output

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `./tools/mage lint` — zero warnings
- [x] `go run ./cmd/tachograph parse testdata/**/*.DDD 2>/dev/null | rg '\\u00'` — no control characters in output
- [x] Record-level golden files updated and committed
- [x] Binary round-trip tests pass for both 168-byte and 252-byte calibration records

🤖 Generated with [Claude Code](https://claude.com/claude-code)