### PR TITLE
fix(dd): treat 0xffffffff timereal as unset

### DIFF
--- a/internal/card/testdata/records/005-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
+++ b/internal/card/testdata/records/005-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
@@ -1829,7 +1829,6 @@
       "vehicleOdometerBeginKm": 339469,
       "vehicleOdometerEndKm": 16777215,
       "vehicleFirstUse": "2026-03-10T00:00:00Z",
-      "vehicleLastUse": "2106-02-07T06:28:15Z",
       "vehicleRegistration": {
         "nation": "FINLAND",
         "number": {

--- a/internal/card/testdata/records/006-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
+++ b/internal/card/testdata/records/006-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
@@ -1848,7 +1848,6 @@
       "vehicleOdometerBeginKm": 340225,
       "vehicleOdometerEndKm": 16777215,
       "vehicleFirstUse": "2026-03-11T00:00:00Z",
-      "vehicleLastUse": "2106-02-07T06:28:15Z",
       "vehicleRegistration": {
         "nation": "FINLAND",
         "number": {

--- a/internal/card/testdata/records/007-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
+++ b/internal/card/testdata/records/007-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
@@ -1867,7 +1867,6 @@
       "vehicleOdometerBeginKm": 341144,
       "vehicleOdometerEndKm": 16777215,
       "vehicleFirstUse": "2026-03-12T00:00:00Z",
-      "vehicleLastUse": "2106-02-07T06:28:15Z",
       "vehicleRegistration": {
         "nation": "FINLAND",
         "number": {

--- a/internal/card/testdata/records/008-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
+++ b/internal/card/testdata/records/008-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
@@ -1525,7 +1525,6 @@
       "vehicleOdometerBeginKm": 342075,
       "vehicleOdometerEndKm": 16777215,
       "vehicleFirstUse": "2026-03-13T06:28:18Z",
-      "vehicleLastUse": "2106-02-07T06:28:15Z",
       "vehicleRegistration": {
         "nation": "FINLAND",
         "number": {

--- a/internal/card/testdata/records/009-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
+++ b/internal/card/testdata/records/009-anonymized/022-EF_VEHICLES_USED-GENERATION_2-DATA.golden.json
@@ -1886,7 +1886,6 @@
       "vehicleOdometerBeginKm": 341911,
       "vehicleOdometerEndKm": 16777215,
       "vehicleFirstUse": "2026-03-13T00:00:00Z",
-      "vehicleLastUse": "2106-02-07T06:28:15Z",
       "vehicleRegistration": {
         "nation": "FINLAND",
         "number": {

--- a/internal/dd/card_vehicle_record.go
+++ b/internal/dd/card_vehicle_record.go
@@ -115,14 +115,18 @@ func (opts MarshalOptions) MarshalCardVehicleRecord(record *ddv1.CardVehicleReco
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal vehicle first use: %w", err)
 	}
-	copy(canvas[6:10], firstUseBytes)
+	if record.GetVehicleFirstUse() != nil {
+		copy(canvas[6:10], firstUseBytes)
+	}
 
 	// Vehicle last use (4 bytes)
 	lastUseBytes, err := opts.MarshalTimeReal(record.GetVehicleLastUse())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal vehicle last use: %w", err)
 	}
-	copy(canvas[10:14], lastUseBytes)
+	if record.GetVehicleLastUse() != nil {
+		copy(canvas[10:14], lastUseBytes)
+	}
 
 	// Vehicle registration (15 bytes)
 	vehicleRegBytes, err := opts.MarshalVehicleRegistration(record.GetVehicleRegistration())

--- a/internal/dd/card_vehicle_record_g2.go
+++ b/internal/dd/card_vehicle_record_g2.go
@@ -122,14 +122,18 @@ func (opts MarshalOptions) MarshalCardVehicleRecordG2(record *ddv1.CardVehicleRe
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal vehicle first use: %w", err)
 	}
-	copy(canvas[6:10], firstUseBytes)
+	if record.GetVehicleFirstUse() != nil {
+		copy(canvas[6:10], firstUseBytes)
+	}
 
 	// Vehicle last use (4 bytes)
 	lastUseBytes, err := opts.MarshalTimeReal(record.GetVehicleLastUse())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal vehicle last use: %w", err)
 	}
-	copy(canvas[10:14], lastUseBytes)
+	if record.GetVehicleLastUse() != nil {
+		copy(canvas[10:14], lastUseBytes)
+	}
 
 	// Vehicle registration (15 bytes)
 	vehicleRegBytes, err := opts.MarshalVehicleRegistration(record.GetVehicleRegistration())

--- a/internal/dd/time_real.go
+++ b/internal/dd/time_real.go
@@ -24,8 +24,8 @@ func (opts UnmarshalOptions) UnmarshalTimeReal(data []byte) (*timestamppb.Timest
 		return nil, fmt.Errorf("invalid data length for TimeReal: got %d, want %d", len(data), lenTimeReal)
 	}
 	timeVal := binary.BigEndian.Uint32(data[:lenTimeReal])
-	if timeVal == 0 {
-		return nil, nil // Zero time is represented as nil
+	if timeVal == 0 || timeVal == ^uint32(0) {
+		return nil, nil // Unset time is represented as nil
 	}
 	return timestamppb.New(time.Unix(int64(timeVal), 0)), nil
 }

--- a/internal/dd/time_real_test.go
+++ b/internal/dd/time_real_test.go
@@ -37,6 +37,11 @@ func TestUnmarshalTimeReal(t *testing.T) {
 			wantIsNil: true,
 		},
 		{
+			name:      "all ones sentinel",
+			input:     []byte{0xFF, 0xFF, 0xFF, 0xFF},
+			wantIsNil: true,
+		},
+		{
 			name:     "2038-01-19 03:14:07 UTC (max int32)",
 			input:    []byte{0x7F, 0xFF, 0xFF, 0xFF},
 			wantUnix: 2147483647,

--- a/internal/dd/vu_calibration_record.go
+++ b/internal/dd/vu_calibration_record.go
@@ -377,10 +377,12 @@ func (opts MarshalOptions) MarshalVuCalibrationRecord(record *ddv1.VuCalibration
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal old time value: %w", err)
 	}
-	if len(oldTimeValueBytes) != 4 {
+	if len(oldTimeValueBytes) != 4 && record.GetOldTimeValue() != nil {
 		return nil, fmt.Errorf("invalid old time value length: got %d, want 4", len(oldTimeValueBytes))
 	}
-	copy(canvas[offset:offset+4], oldTimeValueBytes)
+	if record.GetOldTimeValue() != nil {
+		copy(canvas[offset:offset+4], oldTimeValueBytes)
+	}
 	offset += 4
 
 	// Marshal new time value (4 bytes)
@@ -388,10 +390,12 @@ func (opts MarshalOptions) MarshalVuCalibrationRecord(record *ddv1.VuCalibration
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal new time value: %w", err)
 	}
-	if len(newTimeValueBytes) != 4 {
+	if len(newTimeValueBytes) != 4 && record.GetNewTimeValue() != nil {
 		return nil, fmt.Errorf("invalid new time value length: got %d, want 4", len(newTimeValueBytes))
 	}
-	copy(canvas[offset:offset+4], newTimeValueBytes)
+	if record.GetNewTimeValue() != nil {
+		copy(canvas[offset:offset+4], newTimeValueBytes)
+	}
 	offset += 4
 
 	// Marshal next calibration date (4 bytes)
@@ -399,10 +403,12 @@ func (opts MarshalOptions) MarshalVuCalibrationRecord(record *ddv1.VuCalibration
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal next calibration date: %w", err)
 	}
-	if len(nextCalibrationDateBytes) != 4 {
+	if len(nextCalibrationDateBytes) != 4 && record.GetNextCalibrationDate() != nil {
 		return nil, fmt.Errorf("invalid next calibration date length: got %d, want 4", len(nextCalibrationDateBytes))
 	}
-	copy(canvas[offset:offset+4], nextCalibrationDateBytes)
+	if record.GetNextCalibrationDate() != nil {
+		copy(canvas[offset:offset+4], nextCalibrationDateBytes)
+	}
 	offset += 4
 
 	if offset != size {

--- a/internal/dd/vu_card_iw_record.go
+++ b/internal/dd/vu_card_iw_record.go
@@ -184,7 +184,9 @@ func (opts MarshalOptions) MarshalVuCardIWRecord(record *ddv1.VuCardIWRecord) ([
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal card insertion time: %w", err)
 	}
-	copy(canvas[offset:offset+4], insertionTimeBytes)
+	if record.GetCardInsertionTime() != nil {
+		copy(canvas[offset:offset+4], insertionTimeBytes)
+	}
 	offset += 4
 
 	// vehicleOdometerValueAtInsertion (3 bytes)
@@ -205,7 +207,9 @@ func (opts MarshalOptions) MarshalVuCardIWRecord(record *ddv1.VuCardIWRecord) ([
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal card withdrawal time: %w", err)
 	}
-	copy(canvas[offset:offset+4], withdrawalTimeBytes)
+	if record.GetCardWithdrawalTime() != nil {
+		copy(canvas[offset:offset+4], withdrawalTimeBytes)
+	}
 	offset += 4
 
 	// vehicleOdometerValueAtWithdrawal (3 bytes)

--- a/internal/dd/vu_card_iw_record_g2.go
+++ b/internal/dd/vu_card_iw_record_g2.go
@@ -188,7 +188,9 @@ func (opts MarshalOptions) MarshalVuCardIWRecordG2(record *ddv1.VuCardIWRecordG2
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal card insertion time: %w", err)
 	}
-	copy(canvas[offset:offset+4], insertionTimeBytes)
+	if record.GetCardInsertionTime() != nil {
+		copy(canvas[offset:offset+4], insertionTimeBytes)
+	}
 	offset += 4
 
 	// vehicleOdometerValueAtInsertion (3 bytes)
@@ -209,7 +211,9 @@ func (opts MarshalOptions) MarshalVuCardIWRecordG2(record *ddv1.VuCardIWRecordG2
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal card withdrawal time: %w", err)
 	}
-	copy(canvas[offset:offset+4], withdrawalTimeBytes)
+	if record.GetCardWithdrawalTime() != nil {
+		copy(canvas[offset:offset+4], withdrawalTimeBytes)
+	}
 	offset += 4
 
 	// vehicleOdometerValueAtWithdrawal (3 bytes)

--- a/internal/dd/vu_overspeed_control_data.go
+++ b/internal/dd/vu_overspeed_control_data.go
@@ -90,14 +90,18 @@ func (opts MarshalOptions) MarshalVuOverspeedControlData(controlData *ddv1.VuOve
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal last overspeed control time: %w", err)
 	}
-	copy(canvas[idxLastOverspeedControlTime:idxLastOverspeedControlTime+lenLastOverspeedControlTime], lastControlTime)
+	if controlData.GetLastOverspeedControlTime() != nil {
+		copy(canvas[idxLastOverspeedControlTime:idxLastOverspeedControlTime+lenLastOverspeedControlTime], lastControlTime)
+	}
 
 	// Marshal firstOverspeedSince (4 bytes)
 	firstOverspeedSince, err := opts.MarshalTimeReal(controlData.GetFirstOverspeedSinceLastControl())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal first overspeed since: %w", err)
 	}
-	copy(canvas[idxFirstOverspeedSince:idxFirstOverspeedSince+lenFirstOverspeedSince], firstOverspeedSince)
+	if controlData.GetFirstOverspeedSinceLastControl() != nil {
+		copy(canvas[idxFirstOverspeedSince:idxFirstOverspeedSince+lenFirstOverspeedSince], firstOverspeedSince)
+	}
 
 	// Marshal numberOfOverspeedSince (1 byte)
 	canvas[idxNumberOfOverspeedSince] = byte(controlData.GetNumberOfOverspeedSinceLastControl())

--- a/internal/dd/vu_time_adjustment_record.go
+++ b/internal/dd/vu_time_adjustment_record.go
@@ -122,14 +122,18 @@ func (opts MarshalOptions) MarshalVuTimeAdjustmentRecord(record *ddv1.VuTimeAdju
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal old time value: %w", err)
 	}
-	copy(canvas[idxOldTimeValue:idxOldTimeValue+lenOldTimeValue], oldTime)
+	if record.GetOldTimeValue() != nil {
+		copy(canvas[idxOldTimeValue:idxOldTimeValue+lenOldTimeValue], oldTime)
+	}
 
 	// Marshal newTimeValue (4 bytes)
 	newTime, err := opts.MarshalTimeReal(record.GetNewTimeValue())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal new time value: %w", err)
 	}
-	copy(canvas[idxNewTimeValue:idxNewTimeValue+lenNewTimeValue], newTime)
+	if record.GetNewTimeValue() != nil {
+		copy(canvas[idxNewTimeValue:idxNewTimeValue+lenNewTimeValue], newTime)
+	}
 
 	// Marshal workshopName (36 bytes: 1 byte code page + 35 bytes name)
 	workshopName, err := opts.MarshalStringValue(record.GetWorkshopName())

--- a/internal/security/timereal.go
+++ b/internal/security/timereal.go
@@ -14,6 +14,9 @@ func unmarshalTimeReal(data []byte) (*timestamppb.Timestamp, error) {
 		return nil, fmt.Errorf("invalid TimeReal length: got %d, want 4", len(data))
 	}
 	seconds := binary.BigEndian.Uint32(data)
+	if seconds == 0 || seconds == ^uint32(0) {
+		return nil, nil
+	}
 	// TimeReal is seconds since 1970-01-01 00:00:00 UTC
 	epoch := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	return timestamppb.New(epoch.Add(time.Duration(seconds) * time.Second)), nil

--- a/internal/security/timereal_test.go
+++ b/internal/security/timereal_test.go
@@ -1,0 +1,31 @@
+package security
+
+import "testing"
+
+func TestUnmarshalTimeRealSentinels(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "zero value",
+			input: []byte{0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:  "all ones sentinel",
+			input: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalTimeReal(tt.input)
+			if err != nil {
+				t.Fatalf("unmarshalTimeReal() unexpected error: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("unmarshalTimeReal() = %v, want nil", got)
+			}
+		})
+	}
+}

--- a/internal/vu/overview_gen1.go
+++ b/internal/vu/overview_gen1.go
@@ -353,7 +353,10 @@ func (opts MarshalOptions) MarshalOverviewGen1(overview *vuv1.OverviewGen1) ([]b
 
 	// Use raw_data as canvas if available
 	var canvas []byte
-	if raw := overview.GetRawData(); len(raw) == expectedSize {
+	if raw := overview.GetRawData(); len(raw) == expectedSize+128 {
+		canvas = make([]byte, expectedSize)
+		copy(canvas, raw[:expectedSize])
+	} else if raw := overview.GetRawData(); len(raw) == expectedSize {
 		canvas = make([]byte, len(raw))
 		copy(canvas, raw)
 	} else {
@@ -477,7 +480,9 @@ func (opts MarshalOptions) MarshalOverviewGen1(overview *vuv1.OverviewGen1) ([]b
 		if err != nil {
 			return nil, fmt.Errorf("append lock in time: %w", err)
 		}
-		copy(canvas[offset:offset+4], lockInTimeBytes)
+		if lock.GetLockInTime() != nil {
+			copy(canvas[offset:offset+4], lockInTimeBytes)
+		}
 		offset += 4
 
 		// LockOutTime (4 bytes)
@@ -485,7 +490,9 @@ func (opts MarshalOptions) MarshalOverviewGen1(overview *vuv1.OverviewGen1) ([]b
 		if err != nil {
 			return nil, fmt.Errorf("append lock out time: %w", err)
 		}
-		copy(canvas[offset:offset+4], lockOutTimeBytes)
+		if lock.GetLockOutTime() != nil {
+			copy(canvas[offset:offset+4], lockOutTimeBytes)
+		}
 		offset += 4
 
 		// CompanyName (36 bytes)

--- a/internal/vu/testdata/records/000-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -63,7 +63,6 @@
   "companyLocks": [
     {
       "lockInTime": "2017-08-18T13:40:00Z",
-      "lockOutTime": "2106-02-07T06:28:15Z",
       "companyName": {
         "encoding": "ISO_8859_1",
         "length": 35,

--- a/internal/vu/testdata/records/000-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -1484,8 +1484,6 @@
     }
   ],
   "overspeedingControl": {
-    "lastOverspeedControlTime": "2106-02-07T06:28:15Z",
-    "firstOverspeedSinceLastControl": "2106-02-07T06:28:15Z",
     "numberOfOverspeedSinceLastControl": 0,
     "rawData": "//////////8A"
   },

--- a/internal/vu/testdata/records/001-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -63,7 +63,6 @@
   "companyLocks": [
     {
       "lockInTime": "2016-02-05T12:45:44Z",
-      "lockOutTime": "2106-02-07T06:28:15Z",
       "companyName": {
         "encoding": "ISO_8859_1",
         "length": 35,

--- a/internal/vu/testdata/records/001-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -2394,8 +2394,6 @@
     }
   ],
   "overspeedingControl": {
-    "lastOverspeedControlTime": "2106-02-07T06:28:15Z",
-    "firstOverspeedSinceLastControl": "2106-02-07T06:28:15Z",
     "numberOfOverspeedSinceLastControl": 1,
     "rawData": "//////////8B"
   },

--- a/internal/vu/testdata/records/002-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -63,7 +63,6 @@
   "companyLocks": [
     {
       "lockInTime": "2018-03-23T09:52:31Z",
-      "lockOutTime": "2106-02-07T06:28:15Z",
       "companyName": {
         "encoding": "ISO_8859_1",
         "length": 35,

--- a/internal/vu/testdata/records/002-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -2924,8 +2924,6 @@
     }
   ],
   "overspeedingControl": {
-    "lastOverspeedControlTime": "2106-02-07T06:28:15Z",
-    "firstOverspeedSinceLastControl": "2106-02-07T06:28:15Z",
     "numberOfOverspeedSinceLastControl": 0,
     "rawData": "//////////8A"
   },

--- a/internal/vu/testdata/records/003-anonymized/097-EVENTS_AND_FAULTS_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/097-EVENTS_AND_FAULTS_GEN2_V2.golden.json
@@ -650,8 +650,6 @@
     }
   ],
   "overspeedingControl": {
-    "lastControlTime": "2106-02-07T06:28:15Z",
-    "firstOverspeedSinceLastControl": "2106-02-07T06:28:15Z",
     "numberOfOverspeedSinceLastControl": 0
   },
   "signature": "BgAAAAA=",

--- a/internal/vu/testdata/records/004-anonymized/004-EVENTS_AND_FAULTS_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/004-EVENTS_AND_FAULTS_GEN2_V2.golden.json
@@ -650,8 +650,6 @@
     }
   ],
   "overspeedingControl": {
-    "lastControlTime": "2106-02-07T06:28:15Z",
-    "firstOverspeedSinceLastControl": "2106-02-07T06:28:15Z",
     "numberOfOverspeedSinceLastControl": 0
   },
   "signature": "BgAAAAA=",


### PR DESCRIPTION
## Summary
- decode `0xFFFFFFFF` TimeReal values as unset instead of surfacing year 2106 timestamps
- preserve raw sentinel bytes when nil timestamps are marshaled back into parsed raw-painted records
- refresh the affected golden fixtures to match the corrected JSON output

## Context
- Fleetboard VU files contained `cardWithdrawalTime` values encoded as `FF FF FF FF`
- the parser treated that sentinel as a real Unix timestamp and emitted `2106-02-07T06:28:15Z`
- latest `main@origin` already fixes the separate strict-parse `0x0800` issue

## Test plan
- `go test ./internal/dd ./internal/security`
- `go test ./...`
- reparsed `M_20260310_2259_W1T96342310760431.DDD` and verified the bogus `2106-02-07T06:28:15Z` value no longer appears