### PR TITLE
fix(vu): resolve VU parsing failures for Gen2 V1 files

### DIFF
--- a/internal/card/activity.go
+++ b/internal/card/activity.go
@@ -290,13 +290,21 @@ func NewCyclicRecordIterator(buffer []byte, startPos int, oldestPos int) *cyclic
 // Returns true if a record was found, false if end of chain or error.
 // The iterator traverses backwards from newest to oldest record.
 func (it *cyclicRecordIterator) Next() bool {
-	// Safety backstop: gen2 buffer is 55140 bytes; minimum 12-byte records = ~4595 max.
-	const maxRecords = 5000
+	// Safety limit derived from buffer size: the buffer cannot contain more records
+	// than buffer_size / min_record_size. The iterator rejects records with length < 4
+	// (below), so 4 bytes is the absolute minimum per record. This catches infinite
+	// loops from corrupted linked-list pointers while accepting any valid card,
+	// including cards with >366 daily records (observed on a real Gen1 card with
+	// activityStructureLength=13776 containing 379 daily records).
+	maxRecords := len(it.buffer) / 4
+	if maxRecords == 0 {
+		maxRecords = 1
+	}
 	if it.err != nil {
 		return false
 	}
 	if it.recordCount >= maxRecords {
-		it.err = fmt.Errorf("exceeded maximum record count (%d), possible infinite loop", maxRecords)
+		it.err = fmt.Errorf("exceeded maximum record count (%d for %d-byte buffer), possible infinite loop", maxRecords, len(it.buffer))
 		return false
 	}
 	if len(it.buffer) == 0 {

--- a/internal/dd/full_card_number.go
+++ b/internal/dd/full_card_number.go
@@ -73,7 +73,7 @@ func (opts UnmarshalOptions) UnmarshalFullCardNumber(data []byte) (*ddv1.FullCar
 			return nil, fmt.Errorf("failed to parse driver identification: %w", err)
 		}
 		cardNumber.SetDriverIdentification(driverID)
-	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_COMPANY_CARD:
+	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_CONTROL_CARD, ddv1.EquipmentType_COMPANY_CARD:
 		// OwnerIdentification is 16 bytes
 		ownerID, err := opts.UnmarshalOwnerIdentification(cardNumberData)
 		if err != nil {
@@ -163,7 +163,7 @@ func (opts MarshalOptions) MarshalFullCardNumber(cardNumber *ddv1.FullCardNumber
 			}
 			copy(canvas[2:18], driverBytes)
 		}
-	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_COMPANY_CARD:
+	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_CONTROL_CARD, ddv1.EquipmentType_COMPANY_CARD:
 		if ownerID := cardNumber.GetOwnerIdentification(); ownerID != nil {
 			// OwnerIdentification is 16 bytes
 			ownerBytes, err := opts.MarshalOwnerIdentification(ownerID)
@@ -190,7 +190,7 @@ func (opts MarshalOptions) MarshalFullCardNumberAsString(cardNumber *ddv1.FullCa
 		if driverID := cardNumber.GetDriverIdentification(); driverID != nil {
 			return opts.MarshalIa5StringValue(driverID.GetDriverIdentificationNumber())
 		}
-	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_COMPANY_CARD:
+	case ddv1.EquipmentType_WORKSHOP_CARD, ddv1.EquipmentType_CONTROL_CARD, ddv1.EquipmentType_COMPANY_CARD:
 		if ownerID := cardNumber.GetOwnerIdentification(); ownerID != nil {
 			return opts.MarshalIa5StringValue(ownerID.GetOwnerIdentification())
 		}

--- a/internal/dd/full_card_number.go
+++ b/internal/dd/full_card_number.go
@@ -59,9 +59,14 @@ func (opts UnmarshalOptions) UnmarshalFullCardNumber(data []byte) (*ddv1.FullCar
 	}
 	cardNumber.SetCardType(cardType)
 
-	// Parse issuing member state (1 byte)
-	issuingState := data[1]
-	cardNumber.SetCardIssuingMemberState(ddv1.NationNumeric(issuingState))
+	// Parse issuing member state (1 byte). The byte is a protocol value that
+	// must be mapped through the protocol_enum_value annotation, not cast
+	// directly to the proto enum (e.g. Norway protocol 37 == MONACO enum 37).
+	if issuingState, err := UnmarshalEnum[ddv1.NationNumeric](data[1]); err == nil {
+		cardNumber.SetCardIssuingMemberState(issuingState)
+	} else {
+		cardNumber.SetCardIssuingMemberState(ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED)
+	}
 
 	// Parse card number based on card type (16 bytes)
 	cardNumberData := data[2:18]
@@ -149,8 +154,18 @@ func (opts MarshalOptions) MarshalFullCardNumber(cardNumber *ddv1.FullCardNumber
 	}
 	canvas[0] = cardTypeByte
 
-	// Paint issuing member state (1 byte)
-	canvas[1] = byte(cardNumber.GetCardIssuingMemberState())
+	// Paint issuing member state (1 byte) - map the enum back to its protocol
+	// value. UNSPECIFIED (set by the anonymizer) and UNRECOGNIZED have no
+	// protocol value, so leave the byte as painted from raw_data (or zero).
+	issuingState := cardNumber.GetCardIssuingMemberState()
+	if issuingState != ddv1.NationNumeric_NATION_NUMERIC_UNSPECIFIED &&
+		issuingState != ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED {
+		issuingStateByte, err := MarshalEnum(issuingState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal card issuing member state: %w", err)
+		}
+		canvas[1] = issuingStateByte
+	}
 
 	// Paint card number based on card type (bytes 2-17, 16 bytes total)
 	switch cardNumber.GetCardType() {

--- a/internal/dd/full_card_number_test.go
+++ b/internal/dd/full_card_number_test.go
@@ -1,0 +1,56 @@
+package dd
+
+import (
+	"testing"
+
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// TestUnmarshalFullCardNumber_IssuingState guards against the same enum-mapping
+// regression as the vehicle registration nation: the issuing member state byte
+// must be mapped through the protocol_enum_value annotation, not cast directly
+// to the proto enum. With the raw cast, a Norwegian-issued card (protocol value
+// 37) decoded as MONACO (proto enum value 37). See tacho#1090.
+func TestUnmarshalFullCardNumber_IssuingState(t *testing.T) {
+	// 16-byte DriverIdentification: 14-byte IA5 number + replacement + renewal.
+	driverID := []byte{
+		0x44, 0x52, 0x49, 0x56, 0x45, 0x52, 0x49, 0x44, 0x30, 0x30, 0x30, 0x30, 0x30, 0x31, // "DRIVERID000001"
+		0x31, // replacement index "1"
+		0x31, // renewal index "1"
+	}
+
+	tests := []struct {
+		name        string
+		issuingByte byte
+		wantNation  ddv1.NationNumeric
+	}{
+		{name: "Norway issuing state", issuingByte: 0x25, wantNation: ddv1.NationNumeric_NORWAY},
+		{name: "Monaco issuing state", issuingByte: 0x22, wantNation: ddv1.NationNumeric_MONACO},
+		{name: "Unrecognized issuing state", issuingByte: 0x64, wantNation: ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := append([]byte{0x01, tt.issuingByte}, driverID...) // 0x01 = DRIVER_CARD protocol value
+
+			unmarshalOpts := UnmarshalOptions{PreserveRawData: true}
+			got, err := unmarshalOpts.UnmarshalFullCardNumber(input)
+			if err != nil {
+				t.Fatalf("UnmarshalFullCardNumber() unexpected error: %v", err)
+			}
+			if got.GetCardIssuingMemberState() != tt.wantNation {
+				t.Errorf("GetCardIssuingMemberState() = %v, want %v", got.GetCardIssuingMemberState(), tt.wantNation)
+			}
+
+			// Round-trip: the issuing-state byte must be preserved.
+			var marshalOpts MarshalOptions
+			out, err := marshalOpts.MarshalFullCardNumber(got)
+			if err != nil {
+				t.Fatalf("MarshalFullCardNumber() unexpected error: %v", err)
+			}
+			if out[1] != tt.issuingByte {
+				t.Errorf("round-trip issuing-state byte = 0x%02X, want 0x%02X", out[1], tt.issuingByte)
+			}
+		})
+	}
+}

--- a/internal/dd/vehicle_registration.go
+++ b/internal/dd/vehicle_registration.go
@@ -20,29 +20,48 @@ import (
 // Binary Layout (15 bytes):
 //   - Nation code (1 byte): NationNumeric
 //   - Registration number (14 bytes): codePage (1 byte) + vehicleRegNumber (13 bytes)
+//
+// Some Gen2 V1 vehicle units emit 14-byte records (VehicleRegistrationNumber only,
+// without the nation byte). When 14 bytes are provided, the nation defaults to
+// NATION_NUMERIC_UNSPECIFIED. Note: the marshal function always produces the canonical
+// 15-byte format, so 14-byte inputs are normalized to 15 bytes on round-trip.
 func (opts UnmarshalOptions) UnmarshalVehicleRegistration(data []byte) (*ddv1.VehicleRegistrationIdentification, error) {
-	const lenVehicleRegistration = 15
-
-	if len(data) != lenVehicleRegistration {
-		return nil, fmt.Errorf("invalid data length for VehicleRegistrationIdentification: got %d, want %d", len(data), lenVehicleRegistration)
-	}
+	const (
+		lenWithNation    = 15 // VehicleRegistrationIdentification: nation (1) + VRN (14)
+		lenWithoutNation = 14 // VehicleRegistrationNumber only: codePage (1) + regNumber (13)
+	)
 
 	vehicleReg := &ddv1.VehicleRegistrationIdentification{}
 
-	// Read nation code (1 byte) and convert using protocol annotations
-	if nation, err := UnmarshalEnum[ddv1.NationNumeric](data[0]); err == nil {
-		vehicleReg.SetNation(nation)
-	} else {
-		// Value not recognized - set UNRECOGNIZED (no unrecognized field for this type)
-		vehicleReg.SetNation(ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED)
-	}
+	switch len(data) {
+	case lenWithNation:
+		// Standard: 1 byte nation + 14 bytes VehicleRegistrationNumber
+		if nation, err := UnmarshalEnum[ddv1.NationNumeric](data[0]); err == nil {
+			vehicleReg.SetNation(nation)
+		} else {
+			vehicleReg.SetNation(ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED)
+		}
 
-	// Read registration number (14 bytes: 1 byte code page + 13 bytes string)
-	regNumber, err := opts.UnmarshalStringValue(data[1:lenVehicleRegistration])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse registration number: %w", err)
+		regNumber, err := opts.UnmarshalStringValue(data[1:lenWithNation])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse registration number: %w", err)
+		}
+		vehicleReg.SetNumber(regNumber)
+
+	case lenWithoutNation:
+		// Some Gen2 V1 VUs omit the nation byte, emitting only VehicleRegistrationNumber (14 bytes)
+		vehicleReg.SetNation(ddv1.NationNumeric_NATION_NUMERIC_UNSPECIFIED)
+
+		regNumber, err := opts.UnmarshalStringValue(data[0:lenWithoutNation])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse registration number: %w", err)
+		}
+		vehicleReg.SetNumber(regNumber)
+
+	default:
+		return nil, fmt.Errorf("invalid data length for VehicleRegistrationIdentification: got %d, want %d or %d",
+			len(data), lenWithNation, lenWithoutNation)
 	}
-	vehicleReg.SetNumber(regNumber)
 
 	return vehicleReg, nil
 }

--- a/internal/dd/vehicle_registration_identification.go
+++ b/internal/dd/vehicle_registration_identification.go
@@ -35,10 +35,15 @@ func (opts UnmarshalOptions) UnmarshalVehicleRegistrationIdentification(data []b
 
 	switch len(data) {
 	case lenWithNation:
-		// Standard: 1 byte nation + 14 bytes VehicleRegistrationNumber
-		nationValue := int32(data[0])
-		nation := ddv1.NationNumeric(nationValue)
-		vrn.SetNation(nation)
+		// Standard: 1 byte nation + 14 bytes VehicleRegistrationNumber.
+		// The nation byte is a protocol value that must be mapped through the
+		// protocol_enum_value annotation, not cast directly to the proto enum
+		// (their numbering differs, e.g. Norway protocol 37 == MONACO enum 37).
+		if nation, err := UnmarshalEnum[ddv1.NationNumeric](data[0]); err == nil {
+			vrn.SetNation(nation)
+		} else {
+			vrn.SetNation(ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED)
+		}
 
 		number, err := opts.UnmarshalStringValue(data[1:lenWithNation])
 		if err != nil {
@@ -79,8 +84,17 @@ func (opts MarshalOptions) MarshalVehicleRegistrationIdentification(vrn *ddv1.Ve
 
 	offset := 0
 
-	// Marshal nation (1 byte)
-	canvas[offset] = byte(vrn.GetNation())
+	// Marshal nation (1 byte) - map the enum back to its protocol value.
+	nation := vrn.GetNation()
+	if nation == ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED {
+		// UNRECOGNIZED values should not occur during marshalling
+		return nil, fmt.Errorf("cannot marshal UNRECOGNIZED nation (no unrecognized field)")
+	}
+	nationByte, err := MarshalEnum(nation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal nation: %w", err)
+	}
+	canvas[offset] = nationByte
 	offset += 1
 
 	// Marshal registration number (14 bytes)

--- a/internal/dd/vehicle_registration_identification.go
+++ b/internal/dd/vehicle_registration_identification.go
@@ -20,36 +20,48 @@ import (
 // Binary Layout (fixed length: 15 bytes):
 //   - Vehicle Registration Nation (1 byte): NationNumeric
 //   - Vehicle Registration Number (14 bytes): StringValue (1 byte code page + 13 bytes data)
+//
+// Some Gen2 V1 vehicle units emit 14-byte records (VehicleRegistrationNumber only,
+// without the nation byte). When 14 bytes are provided, the nation defaults to
+// NATION_NUMERIC_UNSPECIFIED. Note: the marshal function always produces the canonical
+// 15-byte format, so 14-byte inputs are normalized to 15 bytes on round-trip.
 func (opts UnmarshalOptions) UnmarshalVehicleRegistrationIdentification(data []byte) (*ddv1.VehicleRegistrationIdentification, error) {
-	const lenVehicleRegistrationIdentification = 15
-
-	if len(data) != lenVehicleRegistrationIdentification {
-		return nil, fmt.Errorf(
-			"invalid data length for VehicleRegistrationIdentification: got %d, want %d",
-			len(data), lenVehicleRegistrationIdentification,
-		)
-	}
+	const (
+		lenWithNation    = 15 // VehicleRegistrationIdentification: nation (1) + VRN (14)
+		lenWithoutNation = 14 // VehicleRegistrationNumber only: codePage (1) + regNumber (13)
+	)
 
 	vrn := &ddv1.VehicleRegistrationIdentification{}
 
-	const (
-		idxNation = 0
-		lenNation = 1
-		idxNumber = 1
-		lenNumber = 14
-	)
+	switch len(data) {
+	case lenWithNation:
+		// Standard: 1 byte nation + 14 bytes VehicleRegistrationNumber
+		nationValue := int32(data[0])
+		nation := ddv1.NationNumeric(nationValue)
+		vrn.SetNation(nation)
 
-	// Parse nation (1 byte)
-	nationValue := int32(data[idxNation])
-	nation := ddv1.NationNumeric(nationValue)
-	vrn.SetNation(nation)
+		number, err := opts.UnmarshalStringValue(data[1:lenWithNation])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse vehicle registration number: %w", err)
+		}
+		vrn.SetNumber(number)
 
-	// Parse registration number (14 bytes)
-	number, err := opts.UnmarshalStringValue(data[idxNumber : idxNumber+lenNumber])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse vehicle registration number: %w", err)
+	case lenWithoutNation:
+		// Some Gen2 V1 VUs omit the nation byte, emitting only VehicleRegistrationNumber (14 bytes)
+		vrn.SetNation(ddv1.NationNumeric_NATION_NUMERIC_UNSPECIFIED)
+
+		number, err := opts.UnmarshalStringValue(data[0:lenWithoutNation])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse vehicle registration number: %w", err)
+		}
+		vrn.SetNumber(number)
+
+	default:
+		return nil, fmt.Errorf(
+			"invalid data length for VehicleRegistrationIdentification: got %d, want %d or %d",
+			len(data), lenWithNation, lenWithoutNation,
+		)
 	}
-	vrn.SetNumber(number)
 
 	return vrn, nil
 }

--- a/internal/dd/vehicle_registration_identification_test.go
+++ b/internal/dd/vehicle_registration_identification_test.go
@@ -1,0 +1,101 @@
+package dd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// TestUnmarshalVehicleRegistrationIdentification_Nation guards against a
+// regression where the nation byte was cast directly to the NationNumeric enum
+// (data[0] interpreted as the proto enum value) instead of being mapped through
+// the protocol_enum_value annotation. With the raw cast, a Norwegian record
+// (protocol value 37) decoded as MONACO (proto enum value 37). See tacho#1090.
+func TestUnmarshalVehicleRegistrationIdentification_Nation(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		wantNation    ddv1.NationNumeric
+		wantRegNumber string
+	}{
+		{
+			// Norway protocol value = 37 (0x25). The raw-cast bug decoded this
+			// as MONACO (proto enum value 37). Real plate from tacho#1090.
+			name:          "Norway with registration JD92527",
+			input:         []byte{0x25, 0x00, 0x4A, 0x44, 0x39, 0x32, 0x35, 0x32, 0x37, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+			wantNation:    ddv1.NationNumeric_NORWAY,
+			wantRegNumber: "JD92527",
+		},
+		{
+			// Monaco protocol value = 34 (0x22), distinct from Norway.
+			name:          "Monaco with registration MC1234",
+			input:         []byte{0x22, 0x00, 0x4D, 0x43, 0x31, 0x32, 0x33, 0x34, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+			wantNation:    ddv1.NationNumeric_MONACO,
+			wantRegNumber: "MC1234",
+		},
+		{
+			name:          "Unrecognized nation code (100)",
+			input:         []byte{0x64, 0x00, 0x54, 0x45, 0x53, 0x54, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+			wantNation:    ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED,
+			wantRegNumber: "TEST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var unmarshalOpts UnmarshalOptions
+			got, err := unmarshalOpts.UnmarshalVehicleRegistrationIdentification(tt.input)
+			if err != nil {
+				t.Fatalf("UnmarshalVehicleRegistrationIdentification() unexpected error: %v", err)
+			}
+			if got.GetNation() != tt.wantNation {
+				t.Errorf("GetNation() = %v, want %v", got.GetNation(), tt.wantNation)
+			}
+			gotRegNumber := ""
+			if got.GetNumber() != nil {
+				gotRegNumber = got.GetNumber().GetValue()
+			}
+			if gotRegNumber != tt.wantRegNumber {
+				t.Errorf("GetNumber().GetValue() = %q, want %q", gotRegNumber, tt.wantRegNumber)
+			}
+		})
+	}
+}
+
+// TestVehicleRegistrationIdentificationRoundTrip verifies that recognised
+// nation codes survive an unmarshal → marshal round-trip byte-for-byte.
+func TestVehicleRegistrationIdentificationRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "Norway with registration JD92527",
+			input: []byte{0x25, 0x00, 0x4A, 0x44, 0x39, 0x32, 0x35, 0x32, 0x37, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+		},
+		{
+			name:  "Monaco with registration MC1234",
+			input: []byte{0x22, 0x00, 0x4D, 0x43, 0x31, 0x32, 0x33, 0x34, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var unmarshalOpts UnmarshalOptions
+			var marshalOpts MarshalOptions
+			vri, err := unmarshalOpts.UnmarshalVehicleRegistrationIdentification(tt.input)
+			if err != nil {
+				t.Fatalf("UnmarshalVehicleRegistrationIdentification() error: %v", err)
+			}
+			got, err := marshalOpts.MarshalVehicleRegistrationIdentification(vri)
+			if err != nil {
+				t.Fatalf("MarshalVehicleRegistrationIdentification() error: %v", err)
+			}
+			if diff := cmp.Diff(tt.input, got); diff != "" {
+				t.Errorf("Round-trip mismatch (-original +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/dd/vehicle_registration_test.go
+++ b/internal/dd/vehicle_registration_test.go
@@ -72,10 +72,10 @@ func TestUnmarshalVehicleRegistration(t *testing.T) {
 			wantRegNumber: "TEST",
 		},
 		{
-			name:       "insufficient data - 14 bytes",
-			input:      []byte{0x12, 0x0F, 0x46, 0x50, 0x41, 0x2D, 0x38, 0x32, 0x39, 0x20, 0x20, 0x20, 0x20, 0x20},
-			wantErr:    true,
-			errMessage: "invalid data length for VehicleRegistrationIdentification",
+			name:          "14-byte VehicleRegistrationNumber without nation",
+			input:         []byte{0x0F, 0x46, 0x50, 0x41, 0x2D, 0x38, 0x32, 0x39, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20},
+			wantNation:    ddv1.NationNumeric_NATION_NUMERIC_UNSPECIFIED,
+			wantRegNumber: "FPA-829",
 		},
 		{
 			name:       "insufficient data - 10 bytes",

--- a/internal/vu/overview_gen2_v2.go
+++ b/internal/vu/overview_gen2_v2.go
@@ -316,8 +316,9 @@ func parseVehicleRegistrationNumberRecordArray(data []byte, offset int) (*ddv1.V
 	var unmarshalOpts dd.UnmarshalOptions
 	var vri *ddv1.VehicleRegistrationIdentification
 	switch recordSize {
-	case 15:
-		// VehicleRegistrationIdentification: 1 nation + 1 codepage + 13 string
+	case 14, 15:
+		// 15: VehicleRegistrationIdentification (nation + codepage + 13-byte string)
+		// 14: VehicleRegistrationNumber with codepage (some VUs omit the nation byte)
 		vri, err = unmarshalOpts.UnmarshalVehicleRegistrationIdentification(data[recordStart:recordEnd])
 	case 13:
 		// VehicleRegistrationNumber: 13-byte IA5String (spec-compliant, unlikely in practice)
@@ -331,7 +332,7 @@ func parseVehicleRegistrationNumberRecordArray(data []byte, offset int) (*ddv1.V
 		number.SetValue(ia5.GetValue())
 		vri.SetNumber(number)
 	default:
-		return nil, 0, fmt.Errorf("unexpected VRN record size: %d (expected 13 or 15)", recordSize)
+		return nil, 0, fmt.Errorf("unexpected VRN record size: %d (expected 13, 14, or 15)", recordSize)
 	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("unmarshal VRN: %w", err)

--- a/internal/vu/technical_data.go
+++ b/internal/vu/technical_data.go
@@ -90,39 +90,45 @@ func sizeOfTechnicalDataGen1(data []byte) (totalSize, signatureSize int, err err
 }
 
 // sizeOfTechnicalDataGen2V1 calculates size by parsing all Gen2 V1 RecordArrays.
+//
+// Per the regulation (Appendix 7, Section 2.2.6.6, TREP 25), Gen2 V1 Technical Data
+// contains up to 8 RecordArrays:
+//
+//	VuIdentificationRecordArray              (recordType 0x19)
+//	VuSensorPairedRecordArray                (recordType 0x20)
+//	VuSensorExternalGNSSCoupledRecordArray   (recordType 0x21)
+//	VuCalibrationRecordArray                 (recordType 0x0c)
+//	VuCardRecordArray                        (recordType 0x0e)
+//	VuITSConsentRecordArray                  (recordType 0x17)
+//	VuPowerSupplyInterruptionRecordArray     (recordType 0x1f)
+//	SignatureRecordArray                     (recordType 0x08)
+//
+// We iterate through all present RecordArrays until we find the Signature (always last).
 func sizeOfTechnicalDataGen2V1(data []byte) (totalSize, signatureSize int, err error) {
 	offset := 0
 
-	// VuIdentificationRecordArray
-	size, sizeErr := sizeOfRecordArray(data, offset)
-	if sizeErr != nil {
-		return 0, 0, fmt.Errorf("VuIdentificationRecordArray: %w", sizeErr)
-	}
-	offset += size
+	const recordTypeSignature = 0x08
 
-	// SensorPairedRecordArray
-	size, sizeErr = sizeOfRecordArray(data, offset)
-	if sizeErr != nil {
-		return 0, 0, fmt.Errorf("SensorPairedRecordArray: %w", sizeErr)
-	}
-	offset += size
+	// Each iteration advances by at least 5 bytes (the RecordArray header size),
+	// so the loop is guaranteed to terminate when offset exceeds len(data).
+	for {
+		if offset+5 > len(data) {
+			return 0, 0, fmt.Errorf("ran out of data before finding SignatureRecordArray at offset %d", offset)
+		}
 
-	// VuCalibrationRecordArray
-	size, sizeErr = sizeOfRecordArray(data, offset)
-	if sizeErr != nil {
-		return 0, 0, fmt.Errorf("VuCalibrationRecordArray: %w", sizeErr)
-	}
-	offset += size
+		recordType := data[offset]
+		size, sizeErr := sizeOfRecordArray(data, offset)
+		if sizeErr != nil {
+			return 0, 0, fmt.Errorf("RecordArray at offset %d (type 0x%02x): %w", offset, recordType, sizeErr)
+		}
 
-	// SignatureRecordArray (last)
-	size, sizeErr = sizeOfRecordArray(data, offset)
-	if sizeErr != nil {
-		return 0, 0, fmt.Errorf("SignatureRecordArray: %w", sizeErr)
-	}
-	signatureSizeGen2 := size
-	offset += size
+		if recordType == recordTypeSignature {
+			offset += size
+			return offset, size, nil
+		}
 
-	return offset, signatureSizeGen2, nil
+		offset += size
+	}
 }
 
 // sizeOfTechnicalDataGen2V2 calculates size by parsing all Gen2 V2 RecordArrays.

--- a/internal/vu/technical_data_gen2_v1.go
+++ b/internal/vu/technical_data_gen2_v1.go
@@ -38,33 +38,53 @@ func unmarshalTechnicalDataGen2V1(value []byte) (*vuv1.TechnicalDataGen2V1, erro
 	td.SetRawData(value)
 	offset := 0
 
-	// VuIdentificationRecordArray
-	ddIdent, bytesRead, err := parseVuIdentificationRecordArrayGen2(data, offset)
-	if err != nil {
-		return nil, fmt.Errorf("parse VuIdentificationRecordArray: %w", err)
-	}
-	td.SetVuIdentification(vuIdentToGen2V1(ddIdent))
-	offset += bytesRead
+	// Gen2 V1 Technical Data contains a variable number of RecordArrays.
+	// Per the regulation (TREP 25), the full set is:
+	//   VuIdentification (0x19), SensorPaired (0x20), SensorExternalGNSSCoupled (0x21),
+	//   VuCalibrationRecord (0x0c), VuCardRecord (0x0e), VuITSConsentRecord (0x17),
+	//   VuPowerSupplyInterruptionRecord (0x1f), Signature (0x08).
+	// We parse known arrays and skip unrecognized ones.
+	for offset < len(data) {
+		recordType, recordSize, noOfRecords, headerSize, err := parseRecordArrayHeader(data, offset)
+		if err != nil {
+			return nil, fmt.Errorf("RecordArray header at offset %d: %w", offset, err)
+		}
 
-	// SensorPairedRecordArray
-	ddSensors, bytesRead, err := parseSensorPairedRecordArrayGen2(data, offset)
-	if err != nil {
-		return nil, fmt.Errorf("parse SensorPairedRecordArray: %w", err)
-	}
-	pairedSensors := make([]*vuv1.TechnicalDataGen2V1_PairedSensor, len(ddSensors))
-	for i, s := range ddSensors {
-		pairedSensors[i] = sensorPairedToGen2V1(s)
-	}
-	td.SetPairedSensors(pairedSensors)
-	offset += bytesRead
+		switch recordType {
+		case 0x19: // VuIdentification
+			ddIdent, bytesRead, err := parseVuIdentificationRecordArrayGen2(data, offset)
+			if err != nil {
+				return nil, fmt.Errorf("parse VuIdentificationRecordArray: %w", err)
+			}
+			td.SetVuIdentification(vuIdentToGen2V1(ddIdent))
+			offset += bytesRead
 
-	// VuCalibrationRecordArray
-	calRecords, bytesRead, err := parseCalibrationRecordArrayGen2V1(data, offset)
-	if err != nil {
-		return nil, fmt.Errorf("parse VuCalibrationRecordArray: %w", err)
+		case 0x20: // SensorPaired
+			ddSensors, bytesRead, err := parseSensorPairedRecordArrayGen2(data, offset)
+			if err != nil {
+				return nil, fmt.Errorf("parse SensorPairedRecordArray: %w", err)
+			}
+			pairedSensors := make([]*vuv1.TechnicalDataGen2V1_PairedSensor, len(ddSensors))
+			for i, s := range ddSensors {
+				pairedSensors[i] = sensorPairedToGen2V1(s)
+			}
+			td.SetPairedSensors(pairedSensors)
+			offset += bytesRead
+
+		case 0x0c: // VuCalibrationRecord
+			calRecords, bytesRead, err := parseCalibrationRecordArrayGen2V1(data, offset)
+			if err != nil {
+				return nil, fmt.Errorf("parse VuCalibrationRecordArray: %w", err)
+			}
+			td.SetCalibrationRecords(calRecords)
+			offset += bytesRead
+
+		default:
+			// Skip RecordArrays we don't semantically parse yet
+			// (SensorExternalGNSSCoupled, VuCard, VuITSConsent, VuPowerSupplyInterruption, etc.)
+			offset += headerSize + int(recordSize)*int(noOfRecords)
+		}
 	}
-	td.SetCalibrationRecords(calRecords)
-	offset += bytesRead
 
 	td.SetSignature(signature)
 
@@ -89,12 +109,20 @@ func (opts MarshalOptions) MarshalTechnicalDataGen2V1(td *vuv1.TechnicalDataGen2
 	var result []byte
 	marshalOpts := dd.MarshalOptions{}
 
+	// Record type constants from Data Dictionary Section 2.120
+	const (
+		rtVuIdentification = 0x19
+		rtSensorPaired     = 0x20
+		rtVuCalibration    = 0x0c
+		rtSignature        = 0x08
+	)
+
 	// VuIdentificationRecordArray (1 record × 124 bytes)
 	vuIdentData, err := marshalVuIdentificationGen2(marshalOpts, td.GetVuIdentification())
 	if err != nil {
 		return nil, fmt.Errorf("marshal VuIdentificationRecordArray: %w", err)
 	}
-	result = appendRecordArrayHeader(result, 0x01, 124, 1)
+	result = appendRecordArrayHeader(result, rtVuIdentification, 124, 1)
 	result = append(result, vuIdentData...)
 
 	// SensorPairedRecordArray (N records × 28 bytes)
@@ -103,7 +131,7 @@ func (opts MarshalOptions) MarshalTechnicalDataGen2V1(td *vuv1.TechnicalDataGen2
 	if err != nil {
 		return nil, fmt.Errorf("marshal SensorPairedRecordArray: %w", err)
 	}
-	result = appendRecordArrayHeader(result, 0x02, 28, uint16(len(sensors)))
+	result = appendRecordArrayHeader(result, rtSensorPaired, 28, uint16(len(sensors)))
 	result = append(result, sensorData...)
 
 	// VuCalibrationRecordArray (N records × 168 bytes)
@@ -112,7 +140,7 @@ func (opts MarshalOptions) MarshalTechnicalDataGen2V1(td *vuv1.TechnicalDataGen2
 	if err != nil {
 		return nil, fmt.Errorf("marshal VuCalibrationRecordArray: %w", err)
 	}
-	result = appendRecordArrayHeader(result, 0x03, 168, uint16(len(calRecords)))
+	result = appendRecordArrayHeader(result, rtVuCalibration, 168, uint16(len(calRecords)))
 	result = append(result, calData...)
 
 	// Signature: stored as complete SignatureRecordArray bytes (header + sig bytes).
@@ -120,7 +148,7 @@ func (opts MarshalOptions) MarshalTechnicalDataGen2V1(td *vuv1.TechnicalDataGen2
 	if sig := td.GetSignature(); len(sig) > 0 {
 		result = append(result, sig...)
 	} else {
-		result = appendRecordArrayHeader(result, 0x04, 0, 0)
+		result = appendRecordArrayHeader(result, rtSignature, 0, 0)
 	}
 	return result, nil
 }
@@ -280,9 +308,12 @@ func parseCalibrationRecordArrayGen2V1(data []byte, offset int) ([]*vuv1.Technic
 		return nil, 0, err
 	}
 
-	const expectedRecordSize = 168
-	if recordSize != expectedRecordSize {
-		return nil, 0, fmt.Errorf("expected Gen2 CalibrationRecord size %d, got %d", expectedRecordSize, recordSize)
+	// Gen2 V1 base calibration record is 168 bytes, but VUs with the ▼M3 amendment
+	// include additional fields (sealDataVu etc.) resulting in larger records (e.g. 222 bytes).
+	// The RecordArray header declares the actual record size; we require at least 168 bytes.
+	const minCalibrationRecordSize = 168
+	if int(recordSize) < minCalibrationRecordSize {
+		return nil, 0, fmt.Errorf("Gen2 CalibrationRecord size %d is below minimum %d", recordSize, minCalibrationRecordSize)
 	}
 
 	var unmarshalOpts dd.UnmarshalOptions
@@ -329,9 +360,13 @@ type gen2CalibrationRecord struct {
 	nextCalibrationDate      *timestamppb.Timestamp
 }
 
-// parseOneCalibrationRecordGen2 parses a single 168-byte Gen2 VuCalibrationRecord.
+// parseOneCalibrationRecordGen2 parses the base 168 bytes of a Gen2 VuCalibrationRecord.
 //
-// Gen2 layout (168 bytes) — identical to Gen1 except workshopCardNumber
+// Gen2 V1 VUs may emit records larger than 168 bytes (e.g. 222 bytes) when they include
+// additional fields such as sealDataVu (per ▼M3 amendment). Only the first 168 bytes
+// (the common Gen2 base fields) are parsed here; any trailing extension bytes are skipped.
+//
+// Gen2 base layout (168 bytes) — identical to Gen1 except workshopCardNumber
 // is FullCardNumberAndGeneration (19 bytes) instead of FullCardNumber (18 bytes):
 //
 //	calibrationPurpose CalibrationPurpose                          -- 1 byte (offset 0)
@@ -352,9 +387,9 @@ type gen2CalibrationRecord struct {
 //	newTimeValue TimeReal                                          -- 4 bytes (offset 160)
 //	nextCalibrationDate TimeReal                                   -- 4 bytes (offset 164)
 func parseOneCalibrationRecordGen2(opts dd.UnmarshalOptions, data []byte) (gen2CalibrationRecord, error) {
-	const lenRecord = 168
-	if len(data) != lenRecord {
-		return gen2CalibrationRecord{}, fmt.Errorf("invalid Gen2 CalibrationRecord size: got %d, want %d", len(data), lenRecord)
+	const minRecordLen = 168
+	if len(data) < minRecordLen {
+		return gen2CalibrationRecord{}, fmt.Errorf("invalid Gen2 CalibrationRecord size: got %d, want >= %d", len(data), minRecordLen)
 	}
 
 	const (

--- a/internal/vu/technical_data_gen2_v1.go
+++ b/internal/vu/technical_data_gen2_v1.go
@@ -210,7 +210,7 @@ func (opts AnonymizeOptions) anonymizeTechnicalDataGen2V1(td *vuv1.TechnicalData
 		anon.SetUnrecognizedPurpose(cal.GetUnrecognizedPurpose())
 		anon.SetWorkshopName(ddOpts.AnonymizeStringValue(cal.GetWorkshopName()))
 		anon.SetWorkshopAddress(ddOpts.AnonymizeStringValue(cal.GetWorkshopAddress()))
-		anon.SetWorkshopCardNumberAndGeneration(ddOpts.AnonymizeFullCardNumberAndGeneration(cal.GetWorkshopCardNumberAndGeneration()))
+		anon.SetWorkshopCardNumber(ddOpts.AnonymizeFullCardNumber(cal.GetWorkshopCardNumber()))
 		anon.SetWorkshopCardExpiryDate(cal.GetWorkshopCardExpiryDate())
 		anon.SetVin(ddOpts.AnonymizeIa5StringValue(cal.GetVin()))
 		anon.SetVehicleRegistration(ddOpts.AnonymizeVehicleRegistrationIdentification(cal.GetVehicleRegistration()))
@@ -344,8 +344,8 @@ type gen2CalibrationRecord struct {
 	unrecognizedPurpose      int32
 	workshopName             *ddv1.StringValue
 	workshopAddress          *ddv1.StringValue
-	workshopCardNumberAndGen *ddv1.FullCardNumberAndGeneration
-	workshopCardExpiryDate   *ddv1.Date
+	workshopCardNumber       *ddv1.FullCardNumber
+	workshopCardExpiryDate   *timestamppb.Timestamp
 	vin                      *ddv1.Ia5StringValue
 	vehicleRegistration      *ddv1.VehicleRegistrationIdentification
 	wVehicleCharConst        int32
@@ -398,26 +398,26 @@ func parseOneCalibrationRecordGen2(opts dd.UnmarshalOptions, data []byte) (gen2C
 		lenWorkshopName       = 36
 		idxWorkshopAddress    = 37
 		lenWorkshopAddress    = 36
-		idxWorkshopCardAndGen = 73
-		lenWorkshopCardAndGen = 19
-		idxWorkshopCardExpiry = 92
+		idxWorkshopCard       = 73
+		lenWorkshopCard       = 18
+		idxWorkshopCardExpiry = 91
 		lenWorkshopCardExpiry = 4
-		idxVIN                = 96
+		idxVIN                = 95
 		lenVIN                = 17
-		idxVehicleReg         = 113
+		idxVehicleReg         = 112
 		lenVehicleReg         = 15
-		idxWVehicleChar       = 128
-		idxKConstant          = 130
-		idxLTyreCirc          = 132
-		idxTyreSize           = 134
+		idxWVehicleChar       = 127
+		idxKConstant          = 129
+		idxLTyreCirc          = 131
+		idxTyreSize           = 133
 		lenTyreSize           = 15
-		idxAuthorisedSpeed    = 149
-		idxOldOdometer        = 150
-		idxNewOdometer        = 153
-		idxOldTimeValue       = 156
+		idxAuthorisedSpeed    = 148
+		idxOldOdometer        = 149
+		idxNewOdometer        = 152
+		idxOldTimeValue       = 155
 		lenTimeValue          = 4
-		idxNewTimeValue       = 160
-		idxNextCalDate        = 164
+		idxNewTimeValue       = 159
+		idxNextCalDate        = 163
 	)
 
 	var r gen2CalibrationRecord
@@ -447,14 +447,14 @@ func parseOneCalibrationRecordGen2(opts dd.UnmarshalOptions, data []byte) (gen2C
 		return gen2CalibrationRecord{}, fmt.Errorf("workshop address: %w", err)
 	}
 
-	// workshopCardNumberAndGeneration (19 bytes)
-	r.workshopCardNumberAndGen, err = opts.UnmarshalFullCardNumberAndGeneration(data[idxWorkshopCardAndGen : idxWorkshopCardAndGen+lenWorkshopCardAndGen])
+	// workshopCardNumber (18 bytes, FullCardNumber)
+	r.workshopCardNumber, err = opts.UnmarshalFullCardNumber(data[idxWorkshopCard : idxWorkshopCard+lenWorkshopCard])
 	if err != nil {
-		return gen2CalibrationRecord{}, fmt.Errorf("workshop card number and generation: %w", err)
+		return gen2CalibrationRecord{}, fmt.Errorf("workshop card number: %w", err)
 	}
 
-	// workshopCardExpiryDate (4 bytes, Datef)
-	r.workshopCardExpiryDate, err = opts.UnmarshalDate(data[idxWorkshopCardExpiry : idxWorkshopCardExpiry+lenWorkshopCardExpiry])
+	// workshopCardExpiryDate (4 bytes, TimeReal)
+	r.workshopCardExpiryDate, err = opts.UnmarshalTimeReal(data[idxWorkshopCardExpiry : idxWorkshopCardExpiry+lenWorkshopCardExpiry])
 	if err != nil {
 		return gen2CalibrationRecord{}, fmt.Errorf("workshop card expiry date: %w", err)
 	}
@@ -529,20 +529,20 @@ func marshalOneCalibrationRecordGen2(opts dd.MarshalOptions, r gen2CalibrationRe
 		idxCalibrationPurpose = 0
 		idxWorkshopName       = 1
 		idxWorkshopAddress    = 37
-		idxWorkshopCardAndGen = 73
-		idxWorkshopCardExpiry = 92
-		idxVIN                = 96
-		idxVehicleReg         = 113
-		idxWVehicleChar       = 128
-		idxKConstant          = 130
-		idxLTyreCirc          = 132
-		idxTyreSize           = 134
-		idxAuthorisedSpeed    = 149
-		idxOldOdometer        = 150
-		idxNewOdometer        = 153
-		idxOldTimeValue       = 156
-		idxNewTimeValue       = 160
-		idxNextCalDate        = 164
+		idxWorkshopCard       = 73
+		idxWorkshopCardExpiry = 91
+		idxVIN                = 95
+		idxVehicleReg         = 112
+		idxWVehicleChar       = 127
+		idxKConstant          = 129
+		idxLTyreCirc          = 131
+		idxTyreSize           = 133
+		idxAuthorisedSpeed    = 148
+		idxOldOdometer        = 149
+		idxNewOdometer        = 152
+		idxOldTimeValue       = 155
+		idxNewTimeValue       = 159
+		idxNextCalDate        = 163
 	)
 
 	// calibrationPurpose (1 byte)
@@ -572,18 +572,18 @@ func marshalOneCalibrationRecordGen2(opts dd.MarshalOptions, r gen2CalibrationRe
 	}
 	copy(canvas[idxWorkshopAddress:idxWorkshopAddress+36], workshopAddressBytes)
 
-	// workshopCardNumberAndGeneration (19 bytes)
-	workshopCardBytes, err := opts.MarshalFullCardNumberAndGeneration(r.workshopCardNumberAndGen)
+	// workshopCardNumber (18 bytes, FullCardNumber)
+	workshopCardBytes, err := opts.MarshalFullCardNumber(r.workshopCardNumber)
 	if err != nil {
-		return nil, fmt.Errorf("workshop card number and generation: %w", err)
+		return nil, fmt.Errorf("workshop card number: %w", err)
 	}
-	if len(workshopCardBytes) != 19 {
-		return nil, fmt.Errorf("workshop card number and generation: expected 19 bytes, got %d", len(workshopCardBytes))
+	if len(workshopCardBytes) != 18 {
+		return nil, fmt.Errorf("workshop card number: expected 18 bytes, got %d", len(workshopCardBytes))
 	}
-	copy(canvas[idxWorkshopCardAndGen:idxWorkshopCardAndGen+19], workshopCardBytes)
+	copy(canvas[idxWorkshopCard:idxWorkshopCard+18], workshopCardBytes)
 
-	// workshopCardExpiryDate (4 bytes)
-	expiryDateBytes, err := opts.MarshalDate(r.workshopCardExpiryDate)
+	// workshopCardExpiryDate (4 bytes, TimeReal)
+	expiryDateBytes, err := opts.MarshalTimeReal(r.workshopCardExpiryDate)
 	if err != nil {
 		return nil, fmt.Errorf("workshop card expiry date: %w", err)
 	}
@@ -675,7 +675,7 @@ func gen2CalibrationToV1(r gen2CalibrationRecord) *vuv1.TechnicalDataGen2V1_Cali
 	rec.SetUnrecognizedPurpose(r.unrecognizedPurpose)
 	rec.SetWorkshopName(r.workshopName)
 	rec.SetWorkshopAddress(r.workshopAddress)
-	rec.SetWorkshopCardNumberAndGeneration(r.workshopCardNumberAndGen)
+	rec.SetWorkshopCardNumber(r.workshopCardNumber)
 	rec.SetWorkshopCardExpiryDate(r.workshopCardExpiryDate)
 	rec.SetVin(r.vin)
 	rec.SetVehicleRegistration(r.vehicleRegistration)
@@ -702,7 +702,7 @@ func gen2CalibrationFromV1(rec *vuv1.TechnicalDataGen2V1_CalibrationRecord) gen2
 		unrecognizedPurpose:      rec.GetUnrecognizedPurpose(),
 		workshopName:             rec.GetWorkshopName(),
 		workshopAddress:          rec.GetWorkshopAddress(),
-		workshopCardNumberAndGen: rec.GetWorkshopCardNumberAndGeneration(),
+		workshopCardNumber:       rec.GetWorkshopCardNumber(),
 		workshopCardExpiryDate:   rec.GetWorkshopCardExpiryDate(),
 		vin:                      rec.GetVin(),
 		vehicleRegistration:      rec.GetVehicleRegistration(),

--- a/internal/vu/technical_data_gen2_v1_calibration_test.go
+++ b/internal/vu/technical_data_gen2_v1_calibration_test.go
@@ -1,0 +1,50 @@
+package vu
+
+import (
+	"testing"
+
+	"github.com/way-platform/tachograph-go/internal/dd"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// TestParseOneCalibrationRecordGen2_Alignment guards against the one-byte
+// misalignment fixed for tacho#1106. The Gen2 V1 VuCalibrationRecord prefix is
+// identical to Gen1 (DD 2.174): a 18-byte FullCardNumber workshop card followed
+// by a TimeReal expiry — NOT a 19-byte FullCardNumberAndGeneration + Date. The
+// extra phantom byte shifted the VIN, vehicle registration, and every following
+// field by +1.
+//
+// This record places the VIN at offset 95 and the registration at offset 112
+// (the spec-correct offsets, matching the Gen2 V2 record). With the phantom
+// generation byte the parser read them at 96/113 and produced corrupted values.
+func TestParseOneCalibrationRecordGen2_Alignment(t *testing.T) {
+	const recordLen = 168
+	data := make([]byte, recordLen)
+
+	// workshopCardNumber: FullCardNumber (18 bytes) at offset 73; 0xFF = no card.
+	data[73] = 0xFF
+
+	// VIN (17 bytes) at offset 95.
+	copy(data[95:112], []byte("YS2P6X20005637947"))
+
+	// vehicleRegistration (15 bytes) at offset 112: nation + codepage + number.
+	data[112] = 0x25 // Norway protocol value
+	data[113] = 0x00 // code page
+	copy(data[114:121], []byte("JD91529"))
+
+	var opts dd.UnmarshalOptions
+	rec, err := parseOneCalibrationRecordGen2(opts, data)
+	if err != nil {
+		t.Fatalf("parseOneCalibrationRecordGen2() unexpected error: %v", err)
+	}
+
+	if got := rec.vin.GetValue(); got != "YS2P6X20005637947" {
+		t.Errorf("vin = %q, want %q", got, "YS2P6X20005637947")
+	}
+	if got := rec.vehicleRegistration.GetNation(); got != ddv1.NationNumeric_NORWAY {
+		t.Errorf("vehicleRegistration nation = %v, want NORWAY", got)
+	}
+	if got := rec.vehicleRegistration.GetNumber().GetValue(); got != "JD91529" {
+		t.Errorf("vehicleRegistration number = %q, want %q", got, "JD91529")
+	}
+}

--- a/internal/vu/technical_data_gen2_v2.go
+++ b/internal/vu/technical_data_gen2_v2.go
@@ -614,8 +614,13 @@ func parseOneCalibrationRecordGen2V2(opts dd.UnmarshalOptions, data []byte) (*vu
 	// byDefaultLoadType (1 byte)
 	rec.SetLoadType(int32(data[idxLoadType]))
 
-	// calibrationCountry (1 byte)
-	rec.SetCalibrationCountry(ddv1.NationNumeric(int32(data[idxCalCountry])))
+	// calibrationCountry (1 byte). Map through the protocol_enum_value
+	// annotation, not a direct enum cast (Norway protocol 37 != MONACO enum 37).
+	if calCountry, err := dd.UnmarshalEnum[ddv1.NationNumeric](data[idxCalCountry]); err == nil {
+		rec.SetCalibrationCountry(calCountry)
+	} else {
+		rec.SetCalibrationCountry(ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED)
+	}
 
 	// calibrationCountryTimestamp (4 bytes)
 	calCountryTs, err := opts.UnmarshalTimeReal(data[idxCalCountryTs : idxCalCountryTs+4])
@@ -937,8 +942,18 @@ func marshalOneCalibrationRecordGen2V2(opts dd.MarshalOptions, rec *vuv1.Technic
 	// byDefaultLoadType (1 byte at offset 246)
 	buf[246] = byte(rec.GetLoadType())
 
-	// calibrationCountry (1 byte at offset 247)
-	buf[247] = byte(rec.GetCalibrationCountry())
+	// calibrationCountry (1 byte at offset 247) - map the enum back to its
+	// protocol value. UNSPECIFIED/UNRECOGNIZED have no protocol value, so leave
+	// the byte zeroed rather than writing the proto enum number.
+	calCountry := rec.GetCalibrationCountry()
+	if calCountry != ddv1.NationNumeric_NATION_NUMERIC_UNSPECIFIED &&
+		calCountry != ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED {
+		calCountryByte, err := dd.MarshalEnum(calCountry)
+		if err != nil {
+			return nil, fmt.Errorf("calibration country: %w", err)
+		}
+		buf[247] = calCountryByte
+	}
 
 	// calibrationCountryTimestamp (4 bytes at offset 248)
 	calCountryTsBytes, err := opts.MarshalTimeReal(rec.GetCalibrationCountryTimestamp())

--- a/internal/vu/technical_data_gen2_v2.go
+++ b/internal/vu/technical_data_gen2_v2.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/way-platform/tachograph-go/internal/dd"
 	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
@@ -1044,16 +1041,8 @@ func gen2V1CalibrationToV2(r gen2CalibrationRecord) *vuv1.TechnicalDataGen2V2_Ca
 	rec.SetUnrecognizedPurpose(r.unrecognizedPurpose)
 	rec.SetWorkshopName(r.workshopName)
 	rec.SetWorkshopAddress(r.workshopAddress)
-	// V1 has FullCardNumberAndGeneration(19); V2 proto has FullCardNumber(18).
-	// Extract just the FullCardNumber from FullCardNumberAndGeneration.
-	if fcng := r.workshopCardNumberAndGen; fcng != nil {
-		rec.SetWorkshopCardNumber(fcng.GetFullCardNumber())
-	}
-	// V1 has Datef expiry; V2 proto has Timestamp.
-	if d := r.workshopCardExpiryDate; d != nil {
-		t := time.Date(int(d.GetYear()), time.Month(d.GetMonth()), int(d.GetDay()), 0, 0, 0, 0, time.UTC)
-		rec.SetWorkshopCardExpiryDate(timestamppb.New(t))
-	}
+	rec.SetWorkshopCardNumber(r.workshopCardNumber)
+	rec.SetWorkshopCardExpiryDate(r.workshopCardExpiryDate)
 	rec.SetVin(r.vin)
 	rec.SetVehicleRegistration(r.vehicleRegistration)
 	rec.SetWVehicleCharacteristicConstant(r.wVehicleCharConst)

--- a/internal/vu/technical_data_gen2_v2_calibration_test.go
+++ b/internal/vu/technical_data_gen2_v2_calibration_test.go
@@ -1,0 +1,49 @@
+package vu
+
+import (
+	"testing"
+
+	"github.com/way-platform/tachograph-go/internal/dd"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// TestParseOneCalibrationRecordGen2V2_CalibrationCountry guards against the same
+// enum-mapping regression as the vehicle registration nation: the calibration
+// country byte (offset 247) must be mapped through the protocol_enum_value
+// annotation, not cast directly to the proto enum. With the raw cast, a
+// Norwegian calibration (protocol value 37) decoded as MONACO (proto enum value
+// 37). See tacho#1090.
+//
+// A 252-byte all-zero record parses cleanly (lenient sub-parsers); only the
+// calibration country byte is varied.
+func TestParseOneCalibrationRecordGen2V2_CalibrationCountry(t *testing.T) {
+	const lenRecord = 252
+	const idxCalCountry = 247
+
+	tests := []struct {
+		name        string
+		countryByte byte
+		want        ddv1.NationNumeric
+	}{
+		{name: "Norway", countryByte: 0x25, want: ddv1.NationNumeric_NORWAY},
+		{name: "Monaco", countryByte: 0x22, want: ddv1.NationNumeric_MONACO},
+		{name: "Default (0x00)", countryByte: 0x00, want: ddv1.NationNumeric_NATION_NUMERIC_DEFAULT},
+		{name: "Unrecognized (100)", countryByte: 0x64, want: ddv1.NationNumeric_NATION_NUMERIC_UNRECOGNIZED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, lenRecord)
+			data[idxCalCountry] = tt.countryByte
+
+			var opts dd.UnmarshalOptions
+			rec, err := parseOneCalibrationRecordGen2V2(opts, data)
+			if err != nil {
+				t.Fatalf("parseOneCalibrationRecordGen2V2() unexpected error: %v", err)
+			}
+			if rec.GetCalibrationCountry() != tt.want {
+				t.Errorf("GetCalibrationCountry() = %v, want %v", rec.GetCalibrationCountry(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/vu/testdata/records/000-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -27,7 +27,7 @@
       "downloadingTime": "2025-09-12T12:35:13Z",
       "fullCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -77,7 +77,7 @@
       },
       "companyCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,

--- a/internal/vu/testdata/records/000-anonymized/002-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/002-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -857,7 +857,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -890,7 +890,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/000-anonymized/004-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/004-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1049,7 +1049,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1082,7 +1082,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/000-anonymized/005-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/005-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1161,7 +1161,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1194,7 +1194,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/000-anonymized/006-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/006-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -977,7 +977,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/000-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -307,7 +307,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -332,7 +332,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -365,7 +365,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -390,7 +390,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -423,7 +423,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -448,7 +448,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -481,7 +481,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -506,7 +506,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -539,7 +539,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -564,7 +564,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -597,7 +597,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -622,7 +622,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -655,7 +655,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -680,7 +680,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -713,7 +713,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -738,7 +738,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -771,7 +771,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -796,7 +796,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -829,7 +829,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -854,7 +854,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -887,7 +887,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -912,7 +912,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -945,7 +945,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -970,7 +970,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1003,7 +1003,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1028,7 +1028,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1081,7 +1081,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1106,7 +1106,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1179,7 +1179,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1204,7 +1204,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1237,7 +1237,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1262,7 +1262,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1295,7 +1295,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1320,7 +1320,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1353,7 +1353,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1378,7 +1378,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1411,7 +1411,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1436,7 +1436,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1505,7 +1505,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,

--- a/internal/vu/testdata/records/000-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
+++ b/internal/vu/testdata/records/000-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
@@ -75,7 +75,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -112,7 +112,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -152,7 +152,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -189,7 +189,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -229,7 +229,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -266,7 +266,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -306,7 +306,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -343,7 +343,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -383,7 +383,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -420,7 +420,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -460,7 +460,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -497,7 +497,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -537,7 +537,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -574,7 +574,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -614,7 +614,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -651,7 +651,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,

--- a/internal/vu/testdata/records/001-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -27,7 +27,7 @@
       "downloadingTime": "2025-09-12T10:16:52Z",
       "fullCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -77,7 +77,7 @@
       },
       "companyCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,

--- a/internal/vu/testdata/records/001-anonymized/002-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/002-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -913,7 +913,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/003-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/003-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -809,7 +809,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/004-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/004-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -993,7 +993,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/005-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/005-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -817,7 +817,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/006-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/006-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -6,7 +6,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -31,7 +31,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -62,7 +62,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -87,7 +87,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -157,7 +157,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -182,7 +182,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -214,7 +214,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -239,7 +239,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -271,7 +271,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -296,7 +296,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -328,7 +328,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -353,7 +353,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -385,7 +385,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -410,7 +410,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -442,7 +442,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -467,7 +467,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -499,7 +499,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -524,7 +524,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -556,7 +556,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -581,7 +581,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -641,7 +641,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -934,7 +934,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -959,7 +959,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -992,7 +992,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1017,7 +1017,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1050,7 +1050,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1075,7 +1075,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1108,7 +1108,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1133,7 +1133,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1166,7 +1166,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1191,7 +1191,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1224,7 +1224,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1249,7 +1249,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1282,7 +1282,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1307,7 +1307,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1340,7 +1340,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1365,7 +1365,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1398,7 +1398,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1423,7 +1423,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1456,7 +1456,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1481,7 +1481,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1513,7 +1513,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1538,7 +1538,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1570,7 +1570,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1595,7 +1595,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1627,7 +1627,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1652,7 +1652,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1684,7 +1684,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1709,7 +1709,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1741,7 +1741,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1766,7 +1766,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1819,7 +1819,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1844,7 +1844,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1957,7 +1957,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1982,7 +1982,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2094,7 +2094,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2119,7 +2119,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2170,7 +2170,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2195,7 +2195,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2227,7 +2227,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2252,7 +2252,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2284,7 +2284,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2309,7 +2309,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2341,7 +2341,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2366,7 +2366,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2407,7 +2407,7 @@
       "averageSpeedKmh": 92,
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/001-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
+++ b/internal/vu/testdata/records/001-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
@@ -75,7 +75,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -112,7 +112,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -152,7 +152,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -189,7 +189,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -229,7 +229,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -266,7 +266,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -306,7 +306,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -343,7 +343,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -383,7 +383,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -420,7 +420,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -460,7 +460,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -497,7 +497,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -537,7 +537,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -574,7 +574,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -614,7 +614,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -651,7 +651,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,

--- a/internal/vu/testdata/records/002-anonymized/000-OVERVIEW_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/000-OVERVIEW_GEN1.golden.json
@@ -27,7 +27,7 @@
       "downloadingTime": "2025-09-10T15:56:17Z",
       "fullCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -77,7 +77,7 @@
       },
       "companyCardNumber": {
         "cardType": "COMPANY_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,

--- a/internal/vu/testdata/records/002-anonymized/002-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/002-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -83,7 +83,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1609,7 +1609,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1642,7 +1642,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1675,7 +1675,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1708,7 +1708,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/002-anonymized/003-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/003-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -393,7 +393,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -426,7 +426,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/002-anonymized/004-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/004-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -777,7 +777,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/002-anonymized/005-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/005-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -83,7 +83,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -969,7 +969,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1002,7 +1002,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/002-anonymized/006-ACTIVITIES_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/006-ACTIVITIES_GEN1.golden.json
@@ -19,7 +19,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -83,7 +83,7 @@
       },
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1257,7 +1257,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1290,7 +1290,7 @@
     {
       "fullCardNumber": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,

--- a/internal/vu/testdata/records/002-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/007-EVENTS_AND_FAULTS_GEN1.golden.json
@@ -96,7 +96,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -121,7 +121,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -243,7 +243,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -268,7 +268,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -428,7 +428,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -621,7 +621,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -646,7 +646,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -679,7 +679,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -704,7 +704,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -737,7 +737,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -762,7 +762,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -795,7 +795,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -820,7 +820,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -853,7 +853,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -875,7 +875,7 @@
       },
       "cardNumberCodriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -897,7 +897,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -919,7 +919,7 @@
       },
       "cardNumberCodriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -949,7 +949,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -974,7 +974,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1007,7 +1007,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1032,7 +1032,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1065,7 +1065,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1090,7 +1090,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1123,7 +1123,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1148,7 +1148,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1181,7 +1181,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1206,7 +1206,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1238,7 +1238,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1263,7 +1263,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1356,7 +1356,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1381,7 +1381,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1654,7 +1654,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1679,7 +1679,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1712,7 +1712,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1737,7 +1737,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1770,7 +1770,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1809,7 +1809,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1834,7 +1834,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1887,7 +1887,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1912,7 +1912,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1945,7 +1945,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -1990,7 +1990,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -2048,7 +2048,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2073,7 +2073,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2106,7 +2106,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2131,7 +2131,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2164,7 +2164,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2203,7 +2203,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2228,7 +2228,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2261,7 +2261,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2299,7 +2299,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2343,7 +2343,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2375,7 +2375,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2400,7 +2400,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2432,7 +2432,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2470,7 +2470,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2495,7 +2495,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2527,7 +2527,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2565,7 +2565,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2590,7 +2590,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2622,7 +2622,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2647,7 +2647,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2679,7 +2679,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2704,7 +2704,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2755,7 +2755,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2780,7 +2780,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2813,7 +2813,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2838,7 +2838,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2871,7 +2871,7 @@
       "endTime": "2020-01-01T00:00:00Z",
       "cardNumberDriverSlotBegin": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2896,7 +2896,7 @@
       },
       "cardNumberDriverSlotEnd": {
         "cardType": "DRIVER_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "driverIdentification": {
           "driverIdentificationNumber": {
             "length": 14,
@@ -2945,7 +2945,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,

--- a/internal/vu/testdata/records/002-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
+++ b/internal/vu/testdata/records/002-anonymized/009-TECHNICAL_DATA_GEN1.golden.json
@@ -75,7 +75,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -112,7 +112,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "NATION_NUMERIC_UNSPECIFIED",
+        "nation": "NATION_NUMERIC_DEFAULT",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -152,7 +152,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -189,7 +189,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -229,7 +229,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -266,7 +266,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -306,7 +306,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -343,7 +343,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -383,7 +383,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -420,7 +420,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -460,7 +460,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -497,7 +497,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -537,7 +537,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -574,7 +574,7 @@
         "rawData": "KioqKioqKioqKioqKioqKio="
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "FINLAND",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,

--- a/internal/vu/testdata/records/003-anonymized/000-OVERVIEW_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/000-OVERVIEW_GEN2_V2.golden.json
@@ -6,7 +6,7 @@
     "value": "*****************"
   },
   "vehicleRegistrationIdentification": {
-    "nation": "PORTUGAL",
+    "nation": "SAN_MARINO",
     "number": {
       "encoding": "ENCODING_UNRECOGNIZED",
       "length": 13,
@@ -26,7 +26,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,

--- a/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -49,7 +49,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -75,7 +75,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -111,7 +111,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -137,7 +137,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -173,7 +173,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -199,7 +199,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -235,7 +235,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -261,7 +261,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -303,7 +303,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -331,7 +331,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -355,7 +355,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -379,7 +379,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -407,7 +407,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -431,7 +431,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -455,7 +455,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -479,7 +479,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -503,7 +503,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -527,7 +527,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -551,7 +551,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -579,7 +579,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,

--- a/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/003-anonymized/099-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -69,32 +69,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "CALIBRATION_PURPOSE_RESERVED",
@@ -131,32 +131,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "ACTIVATION",
@@ -193,32 +193,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "CALIBRATION_PURPOSE_UNSPECIFIED",
@@ -255,32 +255,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     }
   ],
   "pairedSensors": [

--- a/internal/vu/testdata/records/004-anonymized/000-OVERVIEW_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/000-OVERVIEW_GEN2_V2.golden.json
@@ -6,7 +6,7 @@
     "value": "*****************"
   },
   "vehicleRegistrationIdentification": {
-    "nation": "PORTUGAL",
+    "nation": "SAN_MARINO",
     "number": {
       "encoding": "ENCODING_UNRECOGNIZED",
       "length": 13,
@@ -26,7 +26,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,

--- a/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -49,7 +49,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -75,7 +75,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -111,7 +111,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -137,7 +137,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -173,7 +173,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -199,7 +199,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -235,7 +235,7 @@
       },
       "workshopCardNumber": {
         "cardType": "WORKSHOP_CARD",
-        "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+        "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
         "ownerIdentification": {
           "ownerIdentification": {
             "length": 13,
@@ -261,7 +261,7 @@
         "value": "*****************"
       },
       "vehicleRegistration": {
-        "nation": "CZECH_REPUBLIC",
+        "nation": "SPAIN",
         "number": {
           "encoding": "ISO_8859_1",
           "length": 13,
@@ -303,7 +303,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "WORKSHOP_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -331,7 +331,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -355,7 +355,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -379,7 +379,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -407,7 +407,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -431,7 +431,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -455,7 +455,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -479,7 +479,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -503,7 +503,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -527,7 +527,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "DRIVER_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "driverIdentification": {
             "driverIdentificationNumber": {
               "length": 14,
@@ -551,7 +551,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,
@@ -579,7 +579,7 @@
       "fullCardNumberAndGeneration": {
         "fullCardNumber": {
           "cardType": "COMPANY_CARD",
-          "cardIssuingMemberState": "NATION_NUMERIC_UNSPECIFIED",
+          "cardIssuingMemberState": "NATION_NUMERIC_DEFAULT",
           "ownerIdentification": {
             "ownerIdentification": {
               "length": 13,

--- a/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
+++ b/internal/vu/testdata/records/004-anonymized/006-TECHNICAL_DATA_GEN2_V2.golden.json
@@ -69,32 +69,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "CALIBRATION_PURPOSE_RESERVED",
@@ -131,32 +131,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "ACTIVATION",
@@ -193,32 +193,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     },
     {
       "purpose": "CALIBRATION_PURPOSE_UNSPECIFIED",
@@ -255,32 +255,32 @@
           }
         }
       },
-      "workshopCardExpiryDate": "3270-06-26T00:00:00Z",
+      "workshopCardExpiryDate": "1970-02-08T05:25:57Z",
       "vin": {
         "length": 17,
-        "value": "*****************"
+        "value": "W****************"
       },
       "vehicleRegistration": {
-        "nation": "SPAIN",
+        "nation": "SAN_MARINO",
         "number": {
-          "encoding": "ISO_8859_1",
+          "encoding": "ISO_8859_15",
           "length": 13,
-          "value": "*************"
+          "value": "************"
         }
       },
-      "wVehicleCharacteristicConstant": 48185,
-      "kConstantOfRecordingEquipment": 48224,
-      "lTyreCircumferenceEighthsMm": 41011,
+      "wVehicleCharacteristicConstant": 10940,
+      "kConstantOfRecordingEquipment": 14780,
+      "lTyreCircumferenceEighthsMm": 24736,
       "tyreSize": {
         "length": 15,
-        "value": "***************"
+        "value": "3**************"
       },
-      "authorisedSpeedKmh": 4,
-      "oldOdometerValueKm": 7238000,
-      "newOdometerValueKm": 16777000,
-      "oldTimeValue": "2020-01-01T00:00:00Z",
-      "newTimeValue": "2020-01-01T00:00:00Z",
-      "nextCalibrationDate": "2020-01-01T00:00:00Z"
+      "authorisedSpeedKmh": 42,
+      "oldOdometerValueKm": 290417,
+      "newOdometerValueKm": 7405567,
+      "oldTimeValue": "1991-06-18T13:34:25Z",
+      "newTimeValue": "1970-03-13T08:03:45Z",
+      "nextCalibrationDate": "1970-03-13T08:03:45Z"
     }
   ],
   "pairedSensors": [

--- a/proto/gen/go/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.pb.go
@@ -811,29 +811,29 @@ func (b0 TechnicalDataGen2V1_CoupledGnss_builder) Build() *TechnicalDataGen2V1_C
 //
 // See Data Dictionary, Section 2.174, `VuCalibrationRecord`.
 type TechnicalDataGen2V1_CalibrationRecord struct {
-	state                                      protoimpl.MessageState                 `protogen:"opaque.v1"`
-	xxx_hidden_Purpose                         v11.CalibrationPurpose                 `protobuf:"varint,1,opt,name=purpose,enum=wayplatform.connect.tachograph.dd.v1.CalibrationPurpose"`
-	xxx_hidden_UnrecognizedPurpose             int32                                  `protobuf:"varint,2,opt,name=unrecognized_purpose,json=unrecognizedPurpose"`
-	xxx_hidden_WorkshopName                    *v11.StringValue                       `protobuf:"bytes,3,opt,name=workshop_name,json=workshopName"`
-	xxx_hidden_WorkshopAddress                 *v11.StringValue                       `protobuf:"bytes,4,opt,name=workshop_address,json=workshopAddress"`
-	xxx_hidden_WorkshopCardNumberAndGeneration *v11.FullCardNumberAndGeneration       `protobuf:"bytes,5,opt,name=workshop_card_number_and_generation,json=workshopCardNumberAndGeneration"`
-	xxx_hidden_WorkshopCardExpiryDate          *v11.Date                              `protobuf:"bytes,6,opt,name=workshop_card_expiry_date,json=workshopCardExpiryDate"`
-	xxx_hidden_Vin                             *v11.Ia5StringValue                    `protobuf:"bytes,7,opt,name=vin"`
-	xxx_hidden_VehicleRegistration             *v11.VehicleRegistrationIdentification `protobuf:"bytes,8,opt,name=vehicle_registration,json=vehicleRegistration"`
-	xxx_hidden_WVehicleCharacteristicConstant  int32                                  `protobuf:"varint,9,opt,name=w_vehicle_characteristic_constant,json=wVehicleCharacteristicConstant"`
-	xxx_hidden_KConstantOfRecordingEquipment   int32                                  `protobuf:"varint,10,opt,name=k_constant_of_recording_equipment,json=kConstantOfRecordingEquipment"`
-	xxx_hidden_LTyreCircumferenceEighthsMm     int32                                  `protobuf:"varint,11,opt,name=l_tyre_circumference_eighths_mm,json=lTyreCircumferenceEighthsMm"`
-	xxx_hidden_TyreSize                        *v11.Ia5StringValue                    `protobuf:"bytes,12,opt,name=tyre_size,json=tyreSize"`
-	xxx_hidden_AuthorisedSpeedKmh              int32                                  `protobuf:"varint,13,opt,name=authorised_speed_kmh,json=authorisedSpeedKmh"`
-	xxx_hidden_OldOdometerValueKm              int32                                  `protobuf:"varint,14,opt,name=old_odometer_value_km,json=oldOdometerValueKm"`
-	xxx_hidden_NewOdometerValueKm              int32                                  `protobuf:"varint,15,opt,name=new_odometer_value_km,json=newOdometerValueKm"`
-	xxx_hidden_OldTimeValue                    *timestamppb.Timestamp                 `protobuf:"bytes,16,opt,name=old_time_value,json=oldTimeValue"`
-	xxx_hidden_NewTimeValue                    *timestamppb.Timestamp                 `protobuf:"bytes,17,opt,name=new_time_value,json=newTimeValue"`
-	xxx_hidden_NextCalibrationDate             *timestamppb.Timestamp                 `protobuf:"bytes,18,opt,name=next_calibration_date,json=nextCalibrationDate"`
-	XXX_raceDetectHookData                     protoimpl.RaceDetectHookData
-	XXX_presence                               [1]uint32
-	unknownFields                              protoimpl.UnknownFields
-	sizeCache                                  protoimpl.SizeCache
+	state                                     protoimpl.MessageState                 `protogen:"opaque.v1"`
+	xxx_hidden_Purpose                        v11.CalibrationPurpose                 `protobuf:"varint,1,opt,name=purpose,enum=wayplatform.connect.tachograph.dd.v1.CalibrationPurpose"`
+	xxx_hidden_UnrecognizedPurpose            int32                                  `protobuf:"varint,2,opt,name=unrecognized_purpose,json=unrecognizedPurpose"`
+	xxx_hidden_WorkshopName                   *v11.StringValue                       `protobuf:"bytes,3,opt,name=workshop_name,json=workshopName"`
+	xxx_hidden_WorkshopAddress                *v11.StringValue                       `protobuf:"bytes,4,opt,name=workshop_address,json=workshopAddress"`
+	xxx_hidden_WorkshopCardNumber             *v11.FullCardNumber                    `protobuf:"bytes,5,opt,name=workshop_card_number,json=workshopCardNumber"`
+	xxx_hidden_WorkshopCardExpiryDate         *timestamppb.Timestamp                 `protobuf:"bytes,6,opt,name=workshop_card_expiry_date,json=workshopCardExpiryDate"`
+	xxx_hidden_Vin                            *v11.Ia5StringValue                    `protobuf:"bytes,7,opt,name=vin"`
+	xxx_hidden_VehicleRegistration            *v11.VehicleRegistrationIdentification `protobuf:"bytes,8,opt,name=vehicle_registration,json=vehicleRegistration"`
+	xxx_hidden_WVehicleCharacteristicConstant int32                                  `protobuf:"varint,9,opt,name=w_vehicle_characteristic_constant,json=wVehicleCharacteristicConstant"`
+	xxx_hidden_KConstantOfRecordingEquipment  int32                                  `protobuf:"varint,10,opt,name=k_constant_of_recording_equipment,json=kConstantOfRecordingEquipment"`
+	xxx_hidden_LTyreCircumferenceEighthsMm    int32                                  `protobuf:"varint,11,opt,name=l_tyre_circumference_eighths_mm,json=lTyreCircumferenceEighthsMm"`
+	xxx_hidden_TyreSize                       *v11.Ia5StringValue                    `protobuf:"bytes,12,opt,name=tyre_size,json=tyreSize"`
+	xxx_hidden_AuthorisedSpeedKmh             int32                                  `protobuf:"varint,13,opt,name=authorised_speed_kmh,json=authorisedSpeedKmh"`
+	xxx_hidden_OldOdometerValueKm             int32                                  `protobuf:"varint,14,opt,name=old_odometer_value_km,json=oldOdometerValueKm"`
+	xxx_hidden_NewOdometerValueKm             int32                                  `protobuf:"varint,15,opt,name=new_odometer_value_km,json=newOdometerValueKm"`
+	xxx_hidden_OldTimeValue                   *timestamppb.Timestamp                 `protobuf:"bytes,16,opt,name=old_time_value,json=oldTimeValue"`
+	xxx_hidden_NewTimeValue                   *timestamppb.Timestamp                 `protobuf:"bytes,17,opt,name=new_time_value,json=newTimeValue"`
+	xxx_hidden_NextCalibrationDate            *timestamppb.Timestamp                 `protobuf:"bytes,18,opt,name=next_calibration_date,json=nextCalibrationDate"`
+	XXX_raceDetectHookData                    protoimpl.RaceDetectHookData
+	XXX_presence                              [1]uint32
+	unknownFields                             protoimpl.UnknownFields
+	sizeCache                                 protoimpl.SizeCache
 }
 
 func (x *TechnicalDataGen2V1_CalibrationRecord) Reset() {
@@ -891,14 +891,14 @@ func (x *TechnicalDataGen2V1_CalibrationRecord) GetWorkshopAddress() *v11.String
 	return nil
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) GetWorkshopCardNumberAndGeneration() *v11.FullCardNumberAndGeneration {
+func (x *TechnicalDataGen2V1_CalibrationRecord) GetWorkshopCardNumber() *v11.FullCardNumber {
 	if x != nil {
-		return x.xxx_hidden_WorkshopCardNumberAndGeneration
+		return x.xxx_hidden_WorkshopCardNumber
 	}
 	return nil
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) GetWorkshopCardExpiryDate() *v11.Date {
+func (x *TechnicalDataGen2V1_CalibrationRecord) GetWorkshopCardExpiryDate() *timestamppb.Timestamp {
 	if x != nil {
 		return x.xxx_hidden_WorkshopCardExpiryDate
 	}
@@ -1007,11 +1007,11 @@ func (x *TechnicalDataGen2V1_CalibrationRecord) SetWorkshopAddress(v *v11.String
 	x.xxx_hidden_WorkshopAddress = v
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) SetWorkshopCardNumberAndGeneration(v *v11.FullCardNumberAndGeneration) {
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = v
+func (x *TechnicalDataGen2V1_CalibrationRecord) SetWorkshopCardNumber(v *v11.FullCardNumber) {
+	x.xxx_hidden_WorkshopCardNumber = v
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) SetWorkshopCardExpiryDate(v *v11.Date) {
+func (x *TechnicalDataGen2V1_CalibrationRecord) SetWorkshopCardExpiryDate(v *timestamppb.Timestamp) {
 	x.xxx_hidden_WorkshopCardExpiryDate = v
 }
 
@@ -1097,11 +1097,11 @@ func (x *TechnicalDataGen2V1_CalibrationRecord) HasWorkshopAddress() bool {
 	return x.xxx_hidden_WorkshopAddress != nil
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) HasWorkshopCardNumberAndGeneration() bool {
+func (x *TechnicalDataGen2V1_CalibrationRecord) HasWorkshopCardNumber() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_WorkshopCardNumberAndGeneration != nil
+	return x.xxx_hidden_WorkshopCardNumber != nil
 }
 
 func (x *TechnicalDataGen2V1_CalibrationRecord) HasWorkshopCardExpiryDate() bool {
@@ -1213,8 +1213,8 @@ func (x *TechnicalDataGen2V1_CalibrationRecord) ClearWorkshopAddress() {
 	x.xxx_hidden_WorkshopAddress = nil
 }
 
-func (x *TechnicalDataGen2V1_CalibrationRecord) ClearWorkshopCardNumberAndGeneration() {
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = nil
+func (x *TechnicalDataGen2V1_CalibrationRecord) ClearWorkshopCardNumber() {
+	x.xxx_hidden_WorkshopCardNumber = nil
 }
 
 func (x *TechnicalDataGen2V1_CalibrationRecord) ClearWorkshopCardExpiryDate() {
@@ -1291,14 +1291,14 @@ type TechnicalDataGen2V1_CalibrationRecord_builder struct {
 	//
 	// See Data Dictionary, Section 2.2, `Address`.
 	WorkshopAddress *v11.StringValue
-	// The card number and generation of the workshop.
+	// The card number of the workshop.
 	//
-	// See Data Dictionary, Section 2.74, `FullCardNumberAndGeneration`.
-	WorkshopCardNumberAndGeneration *v11.FullCardNumberAndGeneration
+	// See Data Dictionary, Section 2.73, `FullCardNumber`.
+	WorkshopCardNumber *v11.FullCardNumber
 	// The expiry date of the workshop card.
 	//
-	// See Data Dictionary, Section 2.57, `Datef`.
-	WorkshopCardExpiryDate *v11.Date
+	// See Data Dictionary, Section 2.162, `TimeReal`.
+	WorkshopCardExpiryDate *timestamppb.Timestamp
 	// The Vehicle Identification Number.
 	//
 	// See Data Dictionary, Section 2.164, `VehicleIdentificationNumber`.
@@ -1363,7 +1363,7 @@ func (b0 TechnicalDataGen2V1_CalibrationRecord_builder) Build() *TechnicalDataGe
 	}
 	x.xxx_hidden_WorkshopName = b.WorkshopName
 	x.xxx_hidden_WorkshopAddress = b.WorkshopAddress
-	x.xxx_hidden_WorkshopCardNumberAndGeneration = b.WorkshopCardNumberAndGeneration
+	x.xxx_hidden_WorkshopCardNumber = b.WorkshopCardNumber
 	x.xxx_hidden_WorkshopCardExpiryDate = b.WorkshopCardExpiryDate
 	x.xxx_hidden_Vin = b.Vin
 	x.xxx_hidden_VehicleRegistration = b.VehicleRegistration
@@ -1690,7 +1690,7 @@ var File_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v1_proto proto
 
 const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v1_proto_rawDesc = "" +
 	"\n" +
-	"Awayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a>wayplatform/connect/tachograph/dd/v1/calibration_purpose.proto\x1aAwayplatform/connect/tachograph/dd/v1/card_structure_version.proto\x1a/wayplatform/connect/tachograph/dd/v1/date.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1aBwayplatform/connect/tachograph/dd/v1/software_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1aNwayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\x9c\"\n" +
+	"Awayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.proto\x12$wayplatform.connect.tachograph.vu.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a>wayplatform/connect/tachograph/dd/v1/calibration_purpose.proto\x1aAwayplatform/connect/tachograph/dd/v1/card_structure_version.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1aAwayplatform/connect/tachograph/dd/v1/extended_serial_number.proto\x1a;wayplatform/connect/tachograph/dd/v1/full_card_number.proto\x1aJwayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1aBwayplatform/connect/tachograph/dd/v1/software_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1aNwayplatform/connect/tachograph/dd/v1/vehicle_registration_identification.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xe2!\n" +
 	"\x13TechnicalDataGen2V1\x12w\n" +
 	"\x11vu_identification\x18\x01 \x01(\v2J.wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.VuIdentificationR\x10vuIdentification\x12|\n" +
 	"\x13calibration_records\x18\x02 \x03(\v2K.wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecordR\x12calibrationRecords\x12m\n" +
@@ -1717,14 +1717,15 @@ const file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v1_proto_raw
 	"\vCoupledGnss\x12_\n" +
 	"\rserial_number\x18\x01 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumberR\fserialNumber\x12]\n" +
 	"\x0fapproval_number\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x0eapprovalNumber\x12?\n" +
-	"\rcoupling_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\fcouplingDate\x1a\xa7\v\n" +
+	"\rcoupling_date\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\fcouplingDate\x1a\xed\n" +
+	"\n" +
 	"\x11CalibrationRecord\x12R\n" +
 	"\apurpose\x18\x01 \x01(\x0e28.wayplatform.connect.tachograph.dd.v1.CalibrationPurposeR\apurpose\x121\n" +
 	"\x14unrecognized_purpose\x18\x02 \x01(\x05R\x13unrecognizedPurpose\x12V\n" +
 	"\rworkshop_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\fworkshopName\x12\\\n" +
-	"\x10workshop_address\x18\x04 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fworkshopAddress\x12\x8f\x01\n" +
-	"#workshop_card_number_and_generation\x18\x05 \x01(\v2A.wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGenerationR\x1fworkshopCardNumberAndGeneration\x12e\n" +
-	"\x19workshop_card_expiry_date\x18\x06 \x01(\v2*.wayplatform.connect.tachograph.dd.v1.DateR\x16workshopCardExpiryDate\x12F\n" +
+	"\x10workshop_address\x18\x04 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fworkshopAddress\x12f\n" +
+	"\x14workshop_card_number\x18\x05 \x01(\v24.wayplatform.connect.tachograph.dd.v1.FullCardNumberR\x12workshopCardNumber\x12U\n" +
+	"\x19workshop_card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x16workshopCardExpiryDate\x12F\n" +
 	"\x03vin\x18\a \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x03vin\x12z\n" +
 	"\x14vehicle_registration\x18\b \x01(\v2G.wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentificationR\x13vehicleRegistration\x12I\n" +
 	"!w_vehicle_characteristic_constant\x18\t \x01(\x05R\x1ewVehicleCharacteristicConstant\x12H\n" +
@@ -1766,9 +1767,9 @@ var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v1_proto_goTyp
 	(*v11.SoftwareIdentification)(nil),            // 11: wayplatform.connect.tachograph.dd.v1.SoftwareIdentification
 	(*timestamppb.Timestamp)(nil),                 // 12: google.protobuf.Timestamp
 	(v11.CalibrationPurpose)(0),                   // 13: wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
-	(*v11.FullCardNumberAndGeneration)(nil),       // 14: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	(*v11.Date)(nil),                              // 15: wayplatform.connect.tachograph.dd.v1.Date
-	(*v11.VehicleRegistrationIdentification)(nil), // 16: wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
+	(*v11.FullCardNumber)(nil),                    // 14: wayplatform.connect.tachograph.dd.v1.FullCardNumber
+	(*v11.VehicleRegistrationIdentification)(nil), // 15: wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
+	(*v11.FullCardNumberAndGeneration)(nil),       // 16: wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
 	(*v11.CardStructureVersion)(nil),              // 17: wayplatform.connect.tachograph.dd.v1.CardStructureVersion
 	(*v11.DriverIdentification)(nil),              // 18: wayplatform.connect.tachograph.dd.v1.DriverIdentification
 	(*v11.OwnerIdentification)(nil),               // 19: wayplatform.connect.tachograph.dd.v1.OwnerIdentification
@@ -1797,20 +1798,20 @@ var file_wayplatform_connect_tachograph_vu_v1_technical_data_gen2_v1_proto_depId
 	13, // 20: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.purpose:type_name -> wayplatform.connect.tachograph.dd.v1.CalibrationPurpose
 	8,  // 21: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_name:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
 	8,  // 22: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_address:type_name -> wayplatform.connect.tachograph.dd.v1.StringValue
-	14, // 23: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
-	15, // 24: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_card_expiry_date:type_name -> wayplatform.connect.tachograph.dd.v1.Date
+	14, // 23: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_card_number:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumber
+	12, // 24: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.workshop_card_expiry_date:type_name -> google.protobuf.Timestamp
 	9,  // 25: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.vin:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
-	16, // 26: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.vehicle_registration:type_name -> wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
+	15, // 26: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.vehicle_registration:type_name -> wayplatform.connect.tachograph.dd.v1.VehicleRegistrationIdentification
 	9,  // 27: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.tyre_size:type_name -> wayplatform.connect.tachograph.dd.v1.Ia5StringValue
 	12, // 28: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.old_time_value:type_name -> google.protobuf.Timestamp
 	12, // 29: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.new_time_value:type_name -> google.protobuf.Timestamp
 	12, // 30: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CalibrationRecord.next_calibration_date:type_name -> google.protobuf.Timestamp
-	14, // 31: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	16, // 31: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
 	10, // 32: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.card_extended_serial_number:type_name -> wayplatform.connect.tachograph.dd.v1.ExtendedSerialNumber
 	17, // 33: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.card_structure_version:type_name -> wayplatform.connect.tachograph.dd.v1.CardStructureVersion
 	18, // 34: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.driver_identification:type_name -> wayplatform.connect.tachograph.dd.v1.DriverIdentification
 	19, // 35: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.CardRecord.owner_identification:type_name -> wayplatform.connect.tachograph.dd.v1.OwnerIdentification
-	14, // 36: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.ItsConsentRecord.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
+	16, // 36: wayplatform.connect.tachograph.vu.v1.TechnicalDataGen2V1.ItsConsentRecord.full_card_number_and_generation:type_name -> wayplatform.connect.tachograph.dd.v1.FullCardNumberAndGeneration
 	37, // [37:37] is the sub-list for method output_type
 	37, // [37:37] is the sub-list for method input_type
 	37, // [37:37] is the sub-list for extension type_name

--- a/proto/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.proto
+++ b/proto/wayplatform/connect/tachograph/vu/v1/technical_data_gen2_v1.proto
@@ -5,9 +5,9 @@ package wayplatform.connect.tachograph.vu.v1;
 import "google/protobuf/timestamp.proto";
 import "wayplatform/connect/tachograph/dd/v1/calibration_purpose.proto";
 import "wayplatform/connect/tachograph/dd/v1/card_structure_version.proto";
-import "wayplatform/connect/tachograph/dd/v1/date.proto";
 import "wayplatform/connect/tachograph/dd/v1/driver_identification.proto";
 import "wayplatform/connect/tachograph/dd/v1/extended_serial_number.proto";
+import "wayplatform/connect/tachograph/dd/v1/full_card_number.proto";
 import "wayplatform/connect/tachograph/dd/v1/full_card_number_and_generation.proto";
 import "wayplatform/connect/tachograph/dd/v1/owner_identification.proto";
 import "wayplatform/connect/tachograph/dd/v1/software_identification.proto";
@@ -132,15 +132,15 @@ message TechnicalDataGen2V1 {
     // See Data Dictionary, Section 2.2, `Address`.
     wayplatform.connect.tachograph.dd.v1.StringValue workshop_address = 4;
 
-    // The card number and generation of the workshop.
+    // The card number of the workshop.
     //
-    // See Data Dictionary, Section 2.74, `FullCardNumberAndGeneration`.
-    dd.v1.FullCardNumberAndGeneration workshop_card_number_and_generation = 5;
+    // See Data Dictionary, Section 2.73, `FullCardNumber`.
+    dd.v1.FullCardNumber workshop_card_number = 5;
 
     // The expiry date of the workshop card.
     //
-    // See Data Dictionary, Section 2.57, `Datef`.
-    wayplatform.connect.tachograph.dd.v1.Date workshop_card_expiry_date = 6;
+    // See Data Dictionary, Section 2.162, `TimeReal`.
+    google.protobuf.Timestamp workshop_card_expiry_date = 6;
 
     // The Vehicle Identification Number.
     //


### PR DESCRIPTION
## Summary

Fixes three categories of Vehicle Unit parsing errors that caused 754 out of 1023 VU files (73.7%) to fail. After these changes, all 2185 sample files (1162 driver cards + 1023 VU files) parse successfully.

- **CONTROL_CARD in FullCardNumber**: Control cards (protocol byte 3) were missing from the CardNumber CHOICE switch, causing `unsupported card type: 5` errors on 92 VU files. Per Data Dictionary Section 2.26, control cards use OwnerIdentification — same as workshop/company cards.

- **14-byte VehicleRegistrationNumber**: Some Gen2 V1 VUs emit 14-byte records (VRN only) instead of the canonical 15-byte VehicleRegistrationIdentification (nation + VRN). Both VRI parsers now accept 14 or 15 bytes, defaulting nation to UNSPECIFIED for 14-byte inputs. This resolved 663 VU file failures.

- **Gen2 V1 Technical Data structure**: Per regulation TREP 25, Gen2 V1 Technical Data contains up to 8 RecordArrays (including SensorExternalGNSSCoupled, VuCard, VuITSConsent, VuPowerSupplyInterruption from the ▼M3 amendment). The parser previously hardcoded only 4 arrays. Additionally, calibration records were required to be exactly 168 bytes, but ▼M3 VUs emit 222-byte records with sealDataVu. Fixed by iterating dynamically on recordType and accepting records ≥ 168 bytes. Also corrected marshal record type constants to match regulation Section 2.120.

## Test plan

- [ ] All existing unit tests pass (`go test ./...`)
- [ ] Parsed all 2185 sample DDD files with zero failures (was 754 failures before)
- [ ] Verified round-trip fidelity is preserved via raw data passthrough