### PR TITLE
fix(security): validate certificate expiration dates

### DIFF
--- a/internal/security/certificate_expiration_test.go
+++ b/internal/security/certificate_expiration_test.go
@@ -1,0 +1,323 @@
+package security
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/way-platform/tachograph-go/internal/cert/certcache"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ---------------------------------------------------------------------------
+// RSA (Generation 1) — EndOfValidity only, no EffectiveDate
+// ---------------------------------------------------------------------------
+
+func TestRsaCertificate_Expired(t *testing.T) {
+	// Load ERCA root certificate
+	rootData := certcache.Root()
+	root, err := UnmarshalRootCertificate(rootData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal root certificate: %v", err)
+	}
+
+	// Load a real MSCA certificate
+	data, err := os.ReadFile("testdata/certs/g1/finland_tcc37.bin")
+	if err != nil {
+		t.Fatalf("Failed to read certificate: %v", err)
+	}
+
+	cert, err := UnmarshalRsaCertificate(data)
+	if err != nil {
+		t.Fatalf("UnmarshalRsaCertificate() failed: %v", err)
+	}
+
+	// Use a clock set far in the future (year 2099) — well past any certificate's EOV.
+	futureClock := newFakeClock(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Verify with the future clock.  The certificate's EndOfValidity (EOV)
+	// is in the past relative to the clock → should return an expiration error.
+	err = VerifyRsaCertificateWithRootAndClock(cert, root, futureClock)
+	if err == nil {
+		t.Fatal("VerifyRsaCertificateWithRootAndClock() succeeded for expired certificate, want error")
+	}
+
+	// The error message should mention expiration.
+	if !containsAny(err.Error(), "expired", "expir") {
+		t.Errorf("expected expiration error, got: %v", err)
+	}
+}
+
+func TestRsaCertificate_NotYetValid(t *testing.T) {
+	// Generation 1 RSA certificates have only EndOfValidity (EOV), not an
+	// EffectiveDate.  Therefore there is no "not yet valid" state that can be
+	// detected from the certificate content alone.
+	//
+	// This test verifies that when the clock is set BEFORE the EOV
+	// (i.e. the certificate is still valid), verification succeeds.
+
+	rootData := certcache.Root()
+	root, err := UnmarshalRootCertificate(rootData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal root certificate: %v", err)
+	}
+
+	data, err := os.ReadFile("testdata/certs/g1/finland_tcc37.bin")
+	if err != nil {
+		t.Fatalf("Failed to read certificate: %v", err)
+	}
+
+	cert, err := UnmarshalRsaCertificate(data)
+	if err != nil {
+		t.Fatalf("UnmarshalRsaCertificate() failed: %v", err)
+	}
+
+	// Use a clock set to 2025 — the Finland TCC37 cert should still be valid.
+	validClock := newFakeClock(time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	err = VerifyRsaCertificateWithRootAndClock(cert, root, validClock)
+	if err != nil {
+		t.Fatalf("VerifyRsaCertificateWithRootAndClock() failed for valid certificate: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ECC (Generation 2) — CertificateEffectiveDate + CertificateExpirationDate
+// ---------------------------------------------------------------------------
+
+func TestEccCertificate_Expired(t *testing.T) {
+	// Load Gen2 ERCA root certificate
+	const ercaCHR = "18250066869740371713"
+	ercaData, err := os.ReadFile("../cert/certcache/g2/" + ercaCHR + ".bin")
+	if err != nil {
+		t.Skipf("ERCA root certificate not found: %v", err)
+	}
+
+	ercaCert, err := UnmarshalEccCertificate(ercaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal ERCA certificate: %v", err)
+	}
+
+	// Load an MSCA certificate
+	mscaData, err := os.ReadFile("testdata/certs/g2/finland_msca_card42.bin")
+	if err != nil {
+		t.Skipf("MSCA certificate not found: %v", err)
+	}
+
+	mscaCert, err := UnmarshalEccCertificate(mscaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal MSCA certificate: %v", err)
+	}
+
+	// Use a clock set far in the future — well past the certificate's ExpirationDate.
+	futureClock := newFakeClock(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	err = VerifyEccCertificateWithCAClock(mscaCert, ercaCert, futureClock)
+	if err == nil {
+		t.Fatal("VerifyEccCertificateWithCAClock() succeeded for expired certificate, want error")
+	}
+
+	if !containsAny(err.Error(), "expired", "expir") {
+		t.Errorf("expected expiration error, got: %v", err)
+	}
+}
+
+func TestEccCertificate_NotYetValid(t *testing.T) {
+	// Load Gen2 ERCA root certificate
+	const ercaCHR = "18250066869740371713"
+	ercaData, err := os.ReadFile("../cert/certcache/g2/" + ercaCHR + ".bin")
+	if err != nil {
+		t.Skipf("ERCA root certificate not found: %v", err)
+	}
+
+	ercaCert, err := UnmarshalEccCertificate(ercaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal ERCA certificate: %v", err)
+	}
+
+	// Load an MSCA certificate
+	mscaData, err := os.ReadFile("testdata/certs/g2/finland_msca_card42.bin")
+	if err != nil {
+		t.Skipf("MSCA certificate not found: %v", err)
+	}
+
+	mscaCert, err := UnmarshalEccCertificate(mscaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal MSCA certificate: %v", err)
+	}
+
+	// Use a clock set to epoch (1970) — before the certificate's EffectiveDate.
+	pastClock := newFakeClock(time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC))
+
+	err = VerifyEccCertificateWithCAClock(mscaCert, ercaCert, pastClock)
+	if err == nil {
+		t.Fatal("VerifyEccCertificateWithCAClock() succeeded for not-yet-valid certificate, want error")
+	}
+
+	if !containsAny(err.Error(), "not yet valid") {
+		t.Errorf("expected 'not yet valid' error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ECC: valid certificate with correct clock
+// ---------------------------------------------------------------------------
+
+func TestEccCertificate_ValidWithClock(t *testing.T) {
+	// Load Gen2 ERCA root certificate
+	const ercaCHR = "18250066869740371713"
+	ercaData, err := os.ReadFile("../cert/certcache/g2/" + ercaCHR + ".bin")
+	if err != nil {
+		t.Skipf("ERCA root certificate not found: %v", err)
+	}
+
+	ercaCert, err := UnmarshalEccCertificate(ercaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal ERCA certificate: %v", err)
+	}
+
+	mscaData, err := os.ReadFile("testdata/certs/g2/finland_msca_card42.bin")
+	if err != nil {
+		t.Skipf("MSCA certificate not found: %v", err)
+	}
+
+	mscaCert, err := UnmarshalEccCertificate(mscaData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal MSCA certificate: %v", err)
+	}
+
+	// Use a clock set to 2025 — the certificate should be within its validity window.
+	validClock := newFakeClock(time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	err = VerifyEccCertificateWithCAClock(mscaCert, ercaCert, validClock)
+	if err != nil {
+		t.Fatalf("VerifyEccCertificateWithCAClock() failed for valid certificate: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Clock interface tests
+// ---------------------------------------------------------------------------
+
+func TestRealClock_ReturnsCurrentTime(t *testing.T) {
+	c := RealClock{}
+	before := time.Now()
+	got := c.Now()
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("RealClock.Now() = %v, want between %v and %v", got, before, after)
+	}
+}
+
+func TestFakeClock_ReturnsFixedTime(t *testing.T) {
+	fixed := time.Date(2020, 3, 15, 12, 0, 0, 0, time.UTC)
+	c := newFakeClock(fixed)
+	got := c.Now()
+
+	if !got.Equal(fixed) {
+		t.Errorf("fakeClock.Now() = %v, want %v", got, fixed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckCertificateValidity unit tests (timestamp-level, no real certs)
+// ---------------------------------------------------------------------------
+
+func TestCheckCertificateValidity_Expired(t *testing.T) {
+	// Certificate valid 2020-01-01 to 2022-01-01
+	effective := timestamppb.New(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	expiration := timestamppb.New(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Clock at 2023 — past expiration
+	clock := newFakeClock(time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	err := CheckCertificateValidity(effective, expiration, clock)
+	if err == nil {
+		t.Fatal("CheckCertificateValidity() succeeded for expired cert, want error")
+	}
+	if !containsAny(err.Error(), "expired") {
+		t.Errorf("expected expiration error, got: %v", err)
+	}
+}
+
+func TestCheckCertificateValidity_NotYetValid(t *testing.T) {
+	// Certificate valid 2025-01-01 to 2030-01-01
+	effective := timestamppb.New(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	expiration := timestamppb.New(time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Clock at 2024 — before effective date
+	clock := newFakeClock(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	err := CheckCertificateValidity(effective, expiration, clock)
+	if err == nil {
+		t.Fatal("CheckCertificateValidity() succeeded for not-yet-valid cert, want error")
+	}
+	if !containsAny(err.Error(), "not yet valid") {
+		t.Errorf("expected 'not yet valid' error, got: %v", err)
+	}
+}
+
+func TestCheckCertificateValidity_Valid(t *testing.T) {
+	// Certificate valid 2020-01-01 to 2030-01-01
+	effective := timestamppb.New(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	expiration := timestamppb.New(time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Clock at 2025 — within window
+	clock := newFakeClock(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	err := CheckCertificateValidity(effective, expiration, clock)
+	if err != nil {
+		t.Fatalf("CheckCertificateValidity() failed for valid cert: %v", err)
+	}
+}
+
+func TestCheckCertificateValidity_NilDates(t *testing.T) {
+	// When both dates are nil (e.g. 0xFFFFFFFF in Gen1), no error.
+	clock := newFakeClock(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	err := CheckCertificateValidity(nil, nil, clock)
+	if err != nil {
+		t.Fatalf("CheckCertificateValidity() failed with nil dates: %v", err)
+	}
+}
+
+func TestCheckCertificateValidity_NilExpiration(t *testing.T) {
+	// Only effective date set, no expiration — should still pass if now >= effective.
+	effective := timestamppb.New(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	clock := newFakeClock(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	err := CheckCertificateValidity(effective, nil, clock)
+	if err != nil {
+		t.Fatalf("CheckCertificateValidity() failed with nil expiration: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// test doubles
+// ---------------------------------------------------------------------------
+
+// fakeClock is a test double that returns a fixed time.
+type fakeClock struct{ t time.Time }
+
+func newFakeClock(t time.Time) Clock { return fakeClock{t: t} }
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// containsAny returns true if s contains any of the substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(sub) > 0 && len(s) >= len(sub) {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/security/clock.go
+++ b/internal/security/clock.go
@@ -1,0 +1,50 @@
+package security
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Clock abstracts time.Now() so certificate validity checks are deterministic
+// in tests. Production code uses RealClock; tests inject a fakeClock.
+type Clock interface {
+	Now() time.Time
+}
+
+// RealClock implements Clock using the real wall clock.
+type RealClock struct{}
+
+// Now returns the current time.
+func (RealClock) Now() time.Time { return time.Now() }
+
+// CheckCertificateValidity verifies that the current time (from clock) falls
+// within the certificate's validity window [effectiveDate, expirationDate].
+//
+// Either or both timestamps may be nil:
+//   - nil effectiveDate: no "not yet valid" check
+//   - nil expirationDate: no "expired" check (e.g. Gen1 certs with 0xFFFFFFFF EOV)
+//
+// This is the common implementation used by both RSA and ECC verification paths.
+func CheckCertificateValidity(effectiveDate, expirationDate *timestamppb.Timestamp, clock Clock) error {
+	now := clock.Now()
+
+	if effectiveDate != nil {
+		eff := effectiveDate.AsTime()
+		if now.Before(eff) {
+			return fmt.Errorf("certificate not yet valid: effective %s, now %s",
+				eff.Format(time.RFC3339), now.Format(time.RFC3339))
+		}
+	}
+
+	if expirationDate != nil {
+		exp := expirationDate.AsTime()
+		if now.After(exp) {
+			return fmt.Errorf("certificate expired: expiration %s, now %s",
+				exp.Format(time.RFC3339), now.Format(time.RFC3339))
+		}
+	}
+
+	return nil
+}

--- a/internal/security/ecc_verify.go
+++ b/internal/security/ecc_verify.go
@@ -18,6 +18,9 @@ import (
 // This implements certificate chain verification for Generation 2 tachograph certificates
 // as specified in Appendix 11, Section 6.3 "Certificate Verification".
 //
+// Certificate EffectiveDate and ExpirationDate are checked against time.Now().
+// Use VerifyEccCertificateWithEccRootAndClock to inject a custom clock.
+//
 // The signature algorithm used is ECDSA with the hash algorithm determined by the root's
 // key size as specified in CSM_50:
 //   - 256-bit ECC → SHA-256
@@ -27,6 +30,12 @@ import (
 // The certificate signature is verified over the encoded certificate body (including the
 // certificate body tag and length) as specified in CSM_150.
 func VerifyEccCertificateWithEccRoot(cert, root *securityv1.EccCertificate) error {
+	return VerifyEccCertificateWithEccRootAndClock(cert, root, RealClock{})
+}
+
+// VerifyEccCertificateWithEccRootAndClock is like VerifyEccCertificateWithEccRoot but uses
+// the provided Clock for certificate validity checking. This enables deterministic testing.
+func VerifyEccCertificateWithEccRootAndClock(cert, root *securityv1.EccCertificate, clock Clock) error {
 	if cert == nil {
 		return fmt.Errorf("certificate cannot be nil")
 	}
@@ -118,6 +127,17 @@ func VerifyEccCertificateWithEccRoot(cert, root *securityv1.EccCertificate) erro
 		return fmt.Errorf("ECDSA certificate signature verification failed")
 	}
 
+	// Check certificate validity period.
+	// Gen2 ECC certificates have both CertificateEffectiveDate and
+	// CertificateExpirationDate.
+	if err := CheckCertificateValidity(
+		cert.GetCertificateEffectiveDate(),
+		cert.GetCertificateExpirationDate(),
+		clock,
+	); err != nil {
+		return fmt.Errorf("certificate validity check failed: %w", err)
+	}
+
 	return nil
 }
 
@@ -126,9 +146,17 @@ func VerifyEccCertificateWithEccRoot(cert, root *securityv1.EccCertificate) erro
 // This verifies the certificate signature using the CA's public key with ECDSA,
 // following the same procedure as VerifyEccCertificateWithEccRoot but using
 // the CA certificate as the signer.
+//
+// Certificate EffectiveDate and ExpirationDate are checked against time.Now().
+// Use VerifyEccCertificateWithCAClock to inject a custom clock.
 func VerifyEccCertificateWithCA(cert, ca *securityv1.EccCertificate) error {
-	// The verification process is identical whether verifying against root or CA
 	return VerifyEccCertificateWithEccRoot(cert, ca)
+}
+
+// VerifyEccCertificateWithCAClock is like VerifyEccCertificateWithCA but uses the
+// provided Clock for certificate validity checking. This enables deterministic testing.
+func VerifyEccCertificateWithCAClock(cert, ca *securityv1.EccCertificate, clock Clock) error {
+	return VerifyEccCertificateWithEccRootAndClock(cert, ca, clock)
 }
 
 // parseCurveOID parses an elliptic curve OID and returns the hash size in bits

--- a/internal/security/rsa_verify.go
+++ b/internal/security/rsa_verify.go
@@ -16,8 +16,17 @@ import (
 // The CA certificate must have its public key components (modulus and exponent) populated,
 // typically from a previous verification against a higher-level CA or root certificate.
 //
+// Certificate EndOfValidity is checked against time.Now(). Use VerifyRsaCertificateWithCAAndClock
+// to inject a custom clock (e.g. for testing).
+//
 // See Appendix 11, Section 3.3 for the complete specification.
 func VerifyRsaCertificateWithCA(cert *securityv1.RsaCertificate, caCert *securityv1.RsaCertificate) error {
+	return VerifyRsaCertificateWithCAAndClock(cert, caCert, RealClock{})
+}
+
+// VerifyRsaCertificateWithCAAndClock is like VerifyRsaCertificateWithCA but uses the
+// provided Clock for certificate validity checking. This enables deterministic testing.
+func VerifyRsaCertificateWithCAAndClock(cert *securityv1.RsaCertificate, caCert *securityv1.RsaCertificate, clock Clock) error {
 	if caCert == nil {
 		return fmt.Errorf("CA certificate cannot be nil")
 	}
@@ -26,7 +35,7 @@ func VerifyRsaCertificateWithCA(cert *securityv1.RsaCertificate, caCert *securit
 	caExponent := caCert.GetRsaExponent()
 	caCHR := caCert.GetCertificateHolderReference()
 
-	return verifyRsaCertificate(cert, caModulus, caExponent, caCHR)
+	return verifyRsaCertificate(cert, caModulus, caExponent, caCHR, clock)
 }
 
 // VerifyRsaCertificateWithRoot performs signature recovery and verification on an RSA certificate
@@ -35,9 +44,18 @@ func VerifyRsaCertificateWithCA(cert *securityv1.RsaCertificate, caCert *securit
 // The root certificate is trusted a priori and contains the public key components directly.
 // This is typically used to verify Member State CA certificates against the European Root CA.
 //
+// Certificate EndOfValidity is checked against time.Now(). Use VerifyRsaCertificateWithRootAndClock
+// to inject a custom clock (e.g. for testing).
+//
 // See Appendix 11, Section 2.1 for the root certificate format and Section 3.3 for
 // RSA certificate verification.
 func VerifyRsaCertificateWithRoot(cert *securityv1.RsaCertificate, root *securityv1.RootCertificate) error {
+	return VerifyRsaCertificateWithRootAndClock(cert, root, RealClock{})
+}
+
+// VerifyRsaCertificateWithRootAndClock is like VerifyRsaCertificateWithRoot but uses the
+// provided Clock for certificate validity checking. This enables deterministic testing.
+func VerifyRsaCertificateWithRootAndClock(cert *securityv1.RsaCertificate, root *securityv1.RootCertificate, clock Clock) error {
 	if root == nil {
 		return fmt.Errorf("root certificate cannot be nil")
 	}
@@ -46,7 +64,7 @@ func VerifyRsaCertificateWithRoot(cert *securityv1.RsaCertificate, root *securit
 	rootExponent := root.GetRsaExponent()
 	rootKeyID := root.GetKeyId()
 
-	return verifyRsaCertificate(cert, rootModulus, rootExponent, rootKeyID)
+	return verifyRsaCertificate(cert, rootModulus, rootExponent, rootKeyID, clock)
 }
 
 // verifyRsaCertificate is the internal implementation that performs signature recovery
@@ -87,7 +105,7 @@ func VerifyRsaCertificateWithRoot(cert *securityv1.RsaCertificate, root *securit
 // If verification fails, signature_valid is set to false and other fields remain unchanged.
 //
 // See Appendix 11, Section 3.3 for the complete specification.
-func verifyRsaCertificate(cert *securityv1.RsaCertificate, caModulus, caExponent []byte, caCHR string) error {
+func verifyRsaCertificate(cert *securityv1.RsaCertificate, caModulus, caExponent []byte, caCHR string, clock Clock) error {
 	if cert == nil {
 		return fmt.Errorf("certificate cannot be nil")
 	}
@@ -214,6 +232,14 @@ func verifyRsaCertificate(cert *securityv1.RsaCertificate, caModulus, caExponent
 	// If parsing fails (e.g., 0xFFFFFFFF indicating no expiry), we continue anyway
 	eovBytes := cPrime[idxEOV : idxEOV+lenEOV]
 	eov, _ := unmarshalTimeReal(eovBytes)
+
+	// Check certificate validity period.
+	// Gen1 RSA certificates have only EndOfValidity (no EffectiveDate), so
+	// effectiveDate is passed as nil — only the expiration check applies.
+	if err := CheckCertificateValidity(nil, eov, clock); err != nil {
+		cert.SetSignatureValid(false)
+		return fmt.Errorf("certificate validity check failed: %w", err)
+	}
 
 	// Extract RSA public key
 	certModulus := cPrime[idxModulus : idxModulus+lenModulus]


### PR DESCRIPTION
## Summary

- **Severity: CRITICAL (C-1)**
- Adds certificate expiration/validity checking to both RSA (Gen1) and ECC (Gen2) verification paths
- Introduces injectable `Clock` interface for deterministic testing
- Existing public API unchanged — `VerifyRsaCertificateWithRoot` etc. use `RealClock{}` by default

## Problem

Certificate effective/expiration dates are parsed but **never compared** against current time. Expired or not-yet-valid certificates are silently accepted. The enum `CERTIFICATE_VERIFICATION_FAILED` documents "expired or not yet valid" but is never triggered.

## Changes

- `internal/security/clock.go` — `Clock` interface, `RealClock`, `CheckCertificateValidity()`
- `internal/security/rsa_verify.go` — `*AndClock` variants; checks EOV after signature recovery
- `internal/security/ecc_verify.go` — `*AndClock` variants; checks EffectiveDate + ExpirationDate
- `internal/security/certificate_expiration_test.go` — 12 test functions

## Test plan

- [x] Expired RSA cert (clock at 2099) returns error
- [x] Valid RSA cert (clock at 2025) passes
- [x] Expired ECC cert returns error
- [x] Not-yet-valid ECC cert (clock at 1970) returns error
- [x] Valid ECC cert passes
- [x] Nil dates handled gracefully (Gen1 0xFFFFFFFF EOV)
- [x] Unit tests for CheckCertificateValidity