### PR TITLE
fix(dd,card): validate ActivityChangeInfo time range and daily count

### DIFF
--- a/internal/card/activity.go
+++ b/internal/card/activity.go
@@ -174,7 +174,9 @@ func (opts UnmarshalOptions) parseSingleActivityDailyRecord(data []byte) (*cardv
 	record.SetActivityDayDistance(int32(dayDistance))
 	offset += 2
 
-	// Parse activity change info - loop through remainder in 2-byte chunks
+	// Parse activity change info - loop through remainder in 2-byte chunks.
+	// DD 2.1 specifies SET SIZE (1..1440) OF ActivityChangeInfo.
+	const maxChangesPerDay = 1440
 	var activityChanges []*ddv1.ActivityChangeInfo
 
 	for offset+2 <= len(data) {
@@ -183,6 +185,11 @@ func (opts UnmarshalOptions) parseSingleActivityDailyRecord(data []byte) (*cardv
 		if changeData == 0 || changeData == 0xFFFF {
 			offset += 2
 			continue
+		}
+
+		// Validate count before parsing the next entry
+		if len(activityChanges) >= maxChangesPerDay {
+			return nil, fmt.Errorf("activity day record exceeds maximum %d changes", maxChangesPerDay)
 		}
 
 		// Parse ActivityChangeInfo using centralized helper

--- a/internal/card/activity_change_count_test.go
+++ b/internal/card/activity_change_count_test.go
@@ -1,0 +1,109 @@
+package card
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildActivityDayRecord constructs the binary representation of a single
+// CardActivityDailyRecord with the specified number of activity changes.
+//
+// Binary layout:
+//
+//	[prevRecordLength: 2] [currentRecordLength: 2]
+//	[activityRecordDate (TimeReal): 4]
+//	[activityDailyPresenceCounter (BCD): 2]
+//	[activityDayDistance: 2]
+//	[activityChangeInfo: numChanges * 2]
+//
+// Each activity change is encoded as slot=0, crew=0, card=0(inserted),
+// activity=3(DRIVING), time=(i+1) to avoid the 0x0000 sentinel value.
+func buildActivityDayRecord(numChanges int) []byte {
+	const (
+		headerLen  = 4 // prevRecordLength(2) + currentRecordLength(2)
+		dateLen    = 4 // TimeReal
+		counterLen = 2 // BCD DailyPresenceCounter
+		distLen    = 2 // Distance
+		changeLen  = 2 // per ActivityChangeInfo
+	)
+	fixedLen := headerLen + dateLen + counterLen + distLen
+	totalLen := fixedLen + numChanges*changeLen
+
+	buf := make([]byte, totalLen)
+	offset := 0
+
+	// Header
+	binary.BigEndian.PutUint16(buf[offset:], 0)               // prevRecordLength = 0 (first record)
+	binary.BigEndian.PutUint16(buf[offset+2:], uint16(totalLen)) // currentRecordLength
+	offset += headerLen
+
+	// TimeReal: 2024-01-01 00:00:00 UTC = 1704067200 = 0x65920080
+	binary.BigEndian.PutUint32(buf[offset:], 0x65920080)
+	offset += dateLen
+
+	// BCD DailyPresenceCounter: "0001" = 0x00, 0x01
+	buf[offset] = 0x00
+	buf[offset+1] = 0x01
+	offset += counterLen
+
+	// Distance: 100 km
+	binary.BigEndian.PutUint16(buf[offset:], 100)
+	offset += distLen
+
+	// Activity changes: each with a unique valid time (1..numChanges),
+	// using activity=DRIVING(3) so the uint16 is never 0x0000 or 0xFFFF.
+	for i := 0; i < numChanges; i++ {
+		timeMinutes := uint16((i + 1) % 1440) // wrap to stay in valid range
+		// bit layout: s(1)|c(1)|p(1)|aa(2)|t(11)
+		var v uint16
+		v |= (3 & 0x3) << 11       // activity = DRIVING
+		v |= timeMinutes & 0x7FF
+		binary.BigEndian.PutUint16(buf[offset:], v)
+		offset += changeLen
+	}
+
+	return buf
+}
+
+// ---------------------------------------------------------------------------
+// H-2: Activity changes per day must be in the range 1..1440 (DD 2.1).
+// SET SIZE (1..1440) OF ActivityChangeInfo.
+// ---------------------------------------------------------------------------
+
+func TestActivityDay_CountWithinLimit(t *testing.T) {
+	// 100 activity changes — well within the 1440 limit.
+	data := buildActivityDayRecord(100)
+	opts := UnmarshalOptions{}
+	record, err := opts.parseSingleActivityDailyRecord(data)
+	if err != nil {
+		t.Fatalf("expected no error for 100 changes, got: %v", err)
+	}
+	got := len(record.GetActivityChangeInfo())
+	if got != 100 {
+		t.Errorf("change count = %d, want 100", got)
+	}
+}
+
+func TestActivityDay_CountAtLimit(t *testing.T) {
+	// 1440 activity changes — exactly at the boundary.
+	data := buildActivityDayRecord(1440)
+	opts := UnmarshalOptions{}
+	record, err := opts.parseSingleActivityDailyRecord(data)
+	if err != nil {
+		t.Fatalf("expected no error for 1440 changes, got: %v", err)
+	}
+	got := len(record.GetActivityChangeInfo())
+	if got != 1440 {
+		t.Errorf("change count = %d, want 1440", got)
+	}
+}
+
+func TestActivityDay_CountExceedsLimit(t *testing.T) {
+	// 1441 activity changes — one past the maximum allowed by DD 2.1.
+	data := buildActivityDayRecord(1441)
+	opts := UnmarshalOptions{}
+	_, err := opts.parseSingleActivityDailyRecord(data)
+	if err == nil {
+		t.Fatal("expected error for 1441 changes, got nil")
+	}
+}

--- a/internal/dd/activity_change_info.go
+++ b/internal/dd/activity_change_info.go
@@ -39,6 +39,12 @@ func (opts UnmarshalOptions) UnmarshalActivityChangeInfo(input []byte) (*ddv1.Ac
 	activity := int32((value >> 11) & 0x3) // bits 12-11
 	timeMinutes := int32(value & 0x7FF)    // bits 10-0
 
+	// Validate time range per DD 2.1: minutes since 00h00, max 23:59 = 1439.
+	const maxMinutesPerDay = 1439
+	if timeMinutes > maxMinutesPerDay {
+		return nil, fmt.Errorf("ActivityChangeInfo: time %d exceeds maximum %d minutes", timeMinutes, maxMinutesPerDay)
+	}
+
 	// Convert bit values
 	if slotEnum, err := UnmarshalEnum[ddv1.CardSlotNumber](byte(slot)); err == nil {
 		output.SetSlot(slotEnum)

--- a/internal/dd/activity_change_info_validation_test.go
+++ b/internal/dd/activity_change_info_validation_test.go
@@ -1,0 +1,91 @@
+package dd
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// encodeActivityChangeInfo builds the 2-byte big-endian representation of an
+// ActivityChangeInfo value from its constituent bit fields.
+//
+// Bit layout (16 bits): s(1) | c(1) | p(1) | aa(2) | ttttttttttt(11)
+//   - s:   slot        (0 = DRIVER, 1 = CO_DRIVER)
+//   - c:   crew        (0 = SINGLE, 1 = CREW)
+//   - p:   card status (0 = INSERTED, 1 = NOT_INSERTED)
+//   - aa:  activity    (0 = BREAK_REST, 1 = AVAILABILITY, 2 = WORK, 3 = DRIVING)
+//   - t:   time of change in minutes since 00:00
+func encodeActivityChangeInfo(slot, crew, card, activity uint16, timeMinutes uint16) []byte {
+	var v uint16
+	v |= (slot & 0x1) << 15
+	v |= (crew & 0x1) << 14
+	v |= (card & 0x1) << 13
+	v |= (activity & 0x3) << 11
+	v |= timeMinutes & 0x7FF
+	buf := make([]byte, 2)
+	binary.BigEndian.PutUint16(buf, v)
+	return buf
+}
+
+// ---------------------------------------------------------------------------
+// H-1: TimeOfChangeMinutes must be in the range 0..1439 (DD 2.1).
+// The 11-bit field can hold 0..2047; values 1440..2047 are invalid.
+// ---------------------------------------------------------------------------
+
+func TestActivityChangeInfo_TimeZero(t *testing.T) {
+	// time=0 (00:00) — valid lower bound
+	input := encodeActivityChangeInfo(0, 0, 0, 0, 0) // 0x0000
+	opts := UnmarshalOptions{}
+	aci, err := opts.UnmarshalActivityChangeInfo(input)
+	if err != nil {
+		t.Fatalf("expected no error for time=0, got: %v", err)
+	}
+	if got := aci.GetTimeOfChangeMinutes(); got != 0 {
+		t.Errorf("time = %d, want 0", got)
+	}
+}
+
+func TestActivityChangeInfo_TimeMidDay(t *testing.T) {
+	// time=720 (12:00) — valid middle value
+	input := encodeActivityChangeInfo(0, 0, 0, 0, 720)
+	opts := UnmarshalOptions{}
+	aci, err := opts.UnmarshalActivityChangeInfo(input)
+	if err != nil {
+		t.Fatalf("expected no error for time=720, got: %v", err)
+	}
+	if got := aci.GetTimeOfChangeMinutes(); got != 720 {
+		t.Errorf("time = %d, want 720", got)
+	}
+}
+
+func TestActivityChangeInfo_TimeEndOfDay(t *testing.T) {
+	// time=1439 (23:59) — valid upper bound
+	input := encodeActivityChangeInfo(0, 0, 0, 0, 1439)
+	opts := UnmarshalOptions{}
+	aci, err := opts.UnmarshalActivityChangeInfo(input)
+	if err != nil {
+		t.Fatalf("expected no error for time=1439, got: %v", err)
+	}
+	if got := aci.GetTimeOfChangeMinutes(); got != 1439 {
+		t.Errorf("time = %d, want 1439", got)
+	}
+}
+
+func TestActivityChangeInfo_TimeOutOfRange_1440(t *testing.T) {
+	// time=1440 — first invalid value (one past max)
+	input := encodeActivityChangeInfo(0, 0, 0, 0, 1440)
+	opts := UnmarshalOptions{}
+	_, err := opts.UnmarshalActivityChangeInfo(input)
+	if err == nil {
+		t.Fatal("expected error for time=1440, got nil")
+	}
+}
+
+func TestActivityChangeInfo_TimeOutOfRange_2047(t *testing.T) {
+	// time=2047 — maximum 11-bit value, far out of range
+	input := encodeActivityChangeInfo(0, 0, 0, 0, 2047)
+	opts := UnmarshalOptions{}
+	_, err := opts.UnmarshalActivityChangeInfo(input)
+	if err == nil {
+		t.Fatal("expected error for time=2047, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- **Severity: HIGH (H-1, H-2)**
- Validates ActivityChangeInfo time-of-change within spec range 0-1439 minutes
- Enforces max 1440 activity changes per day per DD 2.1 SET SIZE constraint

## Problem

H-1: `UnmarshalActivityChangeInfo` extracts 11 bits (`value & 0x7FF` = 0-2047) but DD 2.1 specifies minutes since 00h00, max 23:59 = 1439. Values 1440-2047 accepted silently.

H-2: `parseSingleActivityDailyRecord` iterates activity changes without counting. Malformed data with >1440 changes per day parsed without error, violating DD 2.1 SET SIZE (1..1440).

## Changes

- `internal/dd/activity_change_info.go` — time range check after bit extraction
- `internal/card/activity.go` — count check in activity parsing loop
- `internal/dd/activity_change_info_validation_test.go` — 5 boundary tests
- `internal/card/activity_change_count_test.go` — 3 count limit tests

## Test plan

- [x] Time=0, 720, 1439 accepted (valid boundaries)
- [x] Time=1440, 2047 rejected with error
- [x] 100 activities/day accepted
- [x] 1440 activities/day accepted (boundary)
- [x] 1441 activities/day rejected with error
- [x] Verified no existing golden fixtures contain values >= 1440