### PR TITLE
Fix/ef parsers and sentinel normalization

### DIFF
--- a/internal/card/anonymize.go
+++ b/internal/card/anonymize.go
@@ -1,8 +1,10 @@
 package card
 
 import (
+	"github.com/way-platform/tachograph-go/internal/dd"
 	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // AnonymizeOptions configures the anonymization of card files.
@@ -122,7 +124,164 @@ func (opts AnonymizeOptions) AnonymizeDriverCardFile(file *cardv1.DriverCardFile
 		if gnssPlaces := tachographG2.GetGnssPlaces(); gnssPlaces != nil {
 			tachographG2.SetGnssPlaces(opts.anonymizeGnssPlaces(gnssPlaces))
 		}
+
+		if companyActivityData := tachographG2.GetCompanyActivityData(); companyActivityData != nil {
+			tachographG2.SetCompanyActivityData(opts.anonymizeCompanyActivityData(companyActivityData))
+		}
+		if placesAuth := tachographG2.GetPlacesAuthentication(); placesAuth != nil {
+			tachographG2.SetPlacesAuthentication(opts.anonymizePlacesAuthentication(placesAuth))
+		}
+		if gnssPlacesAuth := tachographG2.GetGnssPlacesAuthentication(); gnssPlacesAuth != nil {
+			tachographG2.SetGnssPlacesAuthentication(opts.anonymizeGnssPlacesAuthentication(gnssPlacesAuth))
+		}
+		if loadTypeEntries := tachographG2.GetLoadTypeEntries(); loadTypeEntries != nil {
+			tachographG2.SetLoadTypeEntries(opts.anonymizeLoadTypeEntries(loadTypeEntries))
+		}
+		if loadUnloadOps := tachographG2.GetLoadUnloadOperations(); loadUnloadOps != nil {
+			tachographG2.SetLoadUnloadOperations(opts.anonymizeLoadUnloadOperations(loadUnloadOps))
+		}
 	}
 
 	return result, nil
+}
+
+func (opts AnonymizeOptions) anonymizePlacesAuthentication(data *cardv1.PlacesAuthentication) *cardv1.PlacesAuthentication {
+	if data == nil {
+		return nil
+	}
+	result := &cardv1.PlacesAuthentication{}
+	result.SetNewestRecordIndex(data.GetNewestRecordIndex())
+	baseTimestamp := &timestamppb.Timestamp{Seconds: 1577836800}
+	originalRecords := data.GetRecords()
+	anonymizedRecords := make([]*cardv1.PlacesAuthentication_Record, len(originalRecords))
+	for i, rec := range originalRecords {
+		anon := &cardv1.PlacesAuthentication_Record{}
+		if opts.PreserveTimestamps {
+			anon.SetEntryTime(rec.GetEntryTime())
+		} else {
+			anon.SetEntryTime(baseTimestamp)
+		}
+		anon.SetAuthenticationStatus(rec.GetAuthenticationStatus())
+		anonymizedRecords[i] = anon
+	}
+	result.SetRecords(anonymizedRecords)
+	return result
+}
+
+func (opts AnonymizeOptions) anonymizeGnssPlacesAuthentication(data *cardv1.GnssPlacesAuthentication) *cardv1.GnssPlacesAuthentication {
+	if data == nil {
+		return nil
+	}
+	result := &cardv1.GnssPlacesAuthentication{}
+	result.SetNewestRecordIndex(data.GetNewestRecordIndex())
+	baseTimestamp := &timestamppb.Timestamp{Seconds: 1577836800}
+	originalRecords := data.GetRecords()
+	anonymizedRecords := make([]*cardv1.GnssPlacesAuthentication_Record, len(originalRecords))
+	for i, rec := range originalRecords {
+		anon := &cardv1.GnssPlacesAuthentication_Record{}
+		if opts.PreserveTimestamps {
+			anon.SetTimestamp(rec.GetTimestamp())
+		} else {
+			anon.SetTimestamp(baseTimestamp)
+		}
+		anon.SetAuthenticationStatus(rec.GetAuthenticationStatus())
+		anonymizedRecords[i] = anon
+	}
+	result.SetRecords(anonymizedRecords)
+	return result
+}
+
+func (opts AnonymizeOptions) anonymizeLoadTypeEntries(data *cardv1.LoadTypeEntries) *cardv1.LoadTypeEntries {
+	if data == nil {
+		return nil
+	}
+	result := &cardv1.LoadTypeEntries{}
+	result.SetNewestRecordIndex(data.GetNewestRecordIndex())
+	baseTimestamp := &timestamppb.Timestamp{Seconds: 1577836800}
+	originalRecords := data.GetRecords()
+	anonymizedRecords := make([]*cardv1.LoadTypeEntries_Record, len(originalRecords))
+	for i, rec := range originalRecords {
+		anon := &cardv1.LoadTypeEntries_Record{}
+		if opts.PreserveTimestamps {
+			anon.SetTimestamp(rec.GetTimestamp())
+		} else {
+			anon.SetTimestamp(baseTimestamp)
+		}
+		anon.SetLoadTypeEntered(rec.GetLoadTypeEntered())
+		anonymizedRecords[i] = anon
+	}
+	result.SetRecords(anonymizedRecords)
+	return result
+}
+
+func (opts AnonymizeOptions) anonymizeLoadUnloadOperations(data *cardv1.LoadUnloadOperations) *cardv1.LoadUnloadOperations {
+	if data == nil {
+		return nil
+	}
+	result := &cardv1.LoadUnloadOperations{}
+	result.SetNewestRecordIndex(data.GetNewestRecordIndex())
+	baseTimestamp := &timestamppb.Timestamp{Seconds: 1577836800}
+	originalRecords := data.GetRecords()
+	anonymizedRecords := make([]*cardv1.LoadUnloadOperations_Record, len(originalRecords))
+	for i, rec := range originalRecords {
+		anon := &cardv1.LoadUnloadOperations_Record{}
+		if opts.PreserveTimestamps {
+			anon.SetTimestamp(rec.GetTimestamp())
+		} else {
+			anon.SetTimestamp(baseTimestamp)
+		}
+		anon.SetOperationType(rec.GetOperationType())
+		anon.SetGnssPlaceAuthRecord(rec.GetGnssPlaceAuthRecord())
+		anon.SetVehicleOdometerKm(rec.GetVehicleOdometerKm())
+		anonymizedRecords[i] = anon
+	}
+	result.SetRecords(anonymizedRecords)
+	return result
+}
+
+// anonymizeCompanyActivityData creates an anonymized copy of CompanyActivityData,
+// replacing card numbers, vehicle registrations, and timestamps with static test values.
+func (opts AnonymizeOptions) anonymizeCompanyActivityData(data *cardv1.CompanyActivityData) *cardv1.CompanyActivityData {
+	if data == nil {
+		return nil
+	}
+
+	ddOpts := dd.AnonymizeOptions{
+		PreserveDistanceAndTrips: opts.PreserveDistanceAndTrips,
+		PreserveTimestamps:       opts.PreserveTimestamps,
+	}
+
+	result := &cardv1.CompanyActivityData{}
+	result.SetNewestRecordIndex(data.GetNewestRecordIndex())
+
+	// Static base timestamp: 2020-01-01 00:00:00 UTC
+	baseTimestamp := &timestamppb.Timestamp{Seconds: 1577836800}
+
+	originalRecords := data.GetRecords()
+	anonymizedRecords := make([]*cardv1.CompanyActivityData_Record, len(originalRecords))
+	for i, rec := range originalRecords {
+		anon := &cardv1.CompanyActivityData_Record{}
+
+		anon.SetCompanyActivityType(rec.GetCompanyActivityType())
+
+		// Use static test timestamp: 2020-01-01 00:00:00 UTC (epoch: 1577836800)
+		if opts.PreserveTimestamps {
+			anon.SetCompanyActivityTime(rec.GetCompanyActivityTime())
+			anon.SetDownloadPeriodBegin(rec.GetDownloadPeriodBegin())
+			anon.SetDownloadPeriodEnd(rec.GetDownloadPeriodEnd())
+		} else {
+			anon.SetCompanyActivityTime(baseTimestamp)
+			anon.SetDownloadPeriodBegin(baseTimestamp)
+			anon.SetDownloadPeriodEnd(baseTimestamp)
+		}
+
+		// Anonymize card number and vehicle registration
+		anon.SetCardNumberInformation(ddOpts.AnonymizeFullCardNumberAndGeneration(rec.GetCardNumberInformation()))
+		anon.SetVehicleRegistrationInformation(ddOpts.AnonymizeVehicleRegistrationIdentification(rec.GetVehicleRegistrationInformation()))
+
+		anonymizedRecords[i] = anon
+	}
+	result.SetRecords(anonymizedRecords)
+
+	return result
 }

--- a/internal/card/company_activity_data.go
+++ b/internal/card/company_activity_data.go
@@ -128,3 +128,65 @@ func (opts UnmarshalOptions) unmarshalCompanyActivityData(data []byte) (*cardv1.
 
 	return target, nil
 }
+
+// MarshalCompanyActivityData marshals the EF_Company_Activity_Data file.
+func (opts MarshalOptions) MarshalCompanyActivityData(msg *cardv1.CompanyActivityData) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	const lenRecord = 47
+
+	records := msg.GetRecords()
+	dst := make([]byte, 2, 2+len(records)*lenRecord)
+	binary.BigEndian.PutUint16(dst[0:2], uint16(msg.GetNewestRecordIndex()))
+
+	marshalOpts := dd.MarshalOptions{}
+
+	for i, record := range records {
+		rec := make([]byte, lenRecord)
+
+		// companyActivityType (1 byte)
+		activityTypeByte, _ := dd.MarshalEnum(record.GetCompanyActivityType())
+		rec[0] = activityTypeByte
+
+		// companyActivityTime (4 bytes)
+		activityTimeBytes, err := marshalOpts.MarshalTimeReal(record.GetCompanyActivityTime())
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to marshal company activity time: %w", i, err)
+		}
+		copy(rec[1:5], activityTimeBytes)
+
+		// cardNumberInformation (19 bytes)
+		cardNumberBytes, err := marshalOpts.MarshalFullCardNumberAndGeneration(record.GetCardNumberInformation())
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to marshal card number information: %w", i, err)
+		}
+		copy(rec[5:24], cardNumberBytes)
+
+		// vehicleRegistrationInformation (15 bytes)
+		vehicleRegBytes, err := marshalOpts.MarshalVehicleRegistrationIdentification(record.GetVehicleRegistrationInformation())
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to marshal vehicle registration information: %w", i, err)
+		}
+		copy(rec[24:39], vehicleRegBytes)
+
+		// downloadPeriodBegin (4 bytes)
+		downloadBeginBytes, err := marshalOpts.MarshalTimeReal(record.GetDownloadPeriodBegin())
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to marshal download period begin: %w", i, err)
+		}
+		copy(rec[39:43], downloadBeginBytes)
+
+		// downloadPeriodEnd (4 bytes)
+		downloadEndBytes, err := marshalOpts.MarshalTimeReal(record.GetDownloadPeriodEnd())
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to marshal download period end: %w", i, err)
+		}
+		copy(rec[43:47], downloadEndBytes)
+
+		dst = append(dst, rec...)
+	}
+
+	return dst, nil
+}

--- a/internal/card/company_activity_data.go
+++ b/internal/card/company_activity_data.go
@@ -1,0 +1,130 @@
+package card
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/way-platform/tachograph-go/internal/dd"
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// unmarshalCompanyActivityData parses the EF_Company_Activity_Data file.
+//
+// The data type `CompanyActivityData` is specified in the Data Dictionary, Section 2.46.
+//
+// ASN.1 Definition:
+//
+//	CompanyActivityData ::= SEQUENCE {
+//	    companyPointerNewestRecord INTEGER(0..NoOfCompanyActivityRecords-1),
+//	    companyActivityRecords SET SIZE(NoOfCompanyActivityRecords) OF
+//	    companyActivityRecord SEQUENCE {
+//	        companyActivityType   CompanyActivityType,
+//	        companyActivityTime   TimeReal,
+//	        cardNumberInformation FullCardNumberAndGeneration,
+//	        vehicleRegistrationInformation VehicleRegistrationIdentification,
+//	        downloadPeriodBegin   TimeReal,
+//	        downloadPeriodEnd     TimeReal
+//	    }
+//	}
+//
+// Binary Layout:
+//   - Bytes 0-1: companyPointerNewestRecord (2 bytes, big-endian)
+//   - Bytes 2..N: Array of companyActivityRecord (47 bytes each)
+//
+// Record layout (47 bytes):
+//   - Byte  0:     companyActivityType (1 byte)
+//   - Bytes 1-4:   companyActivityTime (4 bytes, TimeReal)
+//   - Bytes 5-23:  cardNumberInformation (19 bytes, FullCardNumberAndGeneration: 18B FullCardNumber + 1B Generation)
+//   - Bytes 24-38: vehicleRegistrationInformation (15 bytes)
+//   - Bytes 39-42: downloadPeriodBegin (4 bytes, TimeReal)
+//   - Bytes 43-46: downloadPeriodEnd (4 bytes, TimeReal)
+func (opts UnmarshalOptions) unmarshalCompanyActivityData(data []byte) (*cardv1.CompanyActivityData, error) {
+	const (
+		lenPointer = 2
+		lenRecord  = 47
+
+		idxActivityType    = 0
+		idxActivityTime    = 1
+		lenActivityTime    = 4
+		idxCardNumber      = 5
+		lenCardNumber      = 19
+		idxVehicleReg      = 24
+		lenVehicleReg      = 15
+		idxDownloadBegin   = 39
+		lenDownloadBegin   = 4
+		idxDownloadEnd     = 43
+		lenDownloadEnd     = 4
+	)
+
+	if len(data) < lenPointer {
+		return nil, fmt.Errorf("data too short for CompanyActivityData: got %d, want at least %d", len(data), lenPointer)
+	}
+
+	recordsData := data[lenPointer:]
+	if len(recordsData)%lenRecord != 0 {
+		return nil, fmt.Errorf("invalid data length for CompanyActivityData records: %d is not a multiple of %d", len(recordsData), lenRecord)
+	}
+
+	newestRecordIndex := int32(binary.BigEndian.Uint16(data[0:lenPointer]))
+
+	target := &cardv1.CompanyActivityData{}
+	target.SetNewestRecordIndex(newestRecordIndex)
+
+	count := len(recordsData) / lenRecord
+	records := make([]*cardv1.CompanyActivityData_Record, count)
+
+	for i := 0; i < count; i++ {
+		start := i * lenRecord
+		rec := recordsData[start : start+lenRecord]
+
+		r := &cardv1.CompanyActivityData_Record{}
+
+		// companyActivityType (1 byte)
+		activityType, err := dd.UnmarshalEnum[ddv1.CompanyActivityType](rec[idxActivityType])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal company activity type: %w", i, err)
+		}
+		r.SetCompanyActivityType(activityType)
+
+		// companyActivityTime (4 bytes, TimeReal)
+		activityTime, err := opts.UnmarshalTimeReal(rec[idxActivityTime : idxActivityTime+lenActivityTime])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal company activity time: %w", i, err)
+		}
+		r.SetCompanyActivityTime(activityTime)
+
+		// cardNumberInformation (19 bytes, FullCardNumberAndGeneration)
+		cardNumber, err := opts.UnmarshalFullCardNumberAndGeneration(rec[idxCardNumber : idxCardNumber+lenCardNumber])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal card number information: %w", i, err)
+		}
+		r.SetCardNumberInformation(cardNumber)
+
+		// vehicleRegistrationInformation (15 bytes)
+		vehicleReg, err := opts.UnmarshalVehicleRegistrationIdentification(rec[idxVehicleReg : idxVehicleReg+lenVehicleReg])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal vehicle registration information: %w", i, err)
+		}
+		r.SetVehicleRegistrationInformation(vehicleReg)
+
+		// downloadPeriodBegin (4 bytes, TimeReal)
+		downloadBegin, err := opts.UnmarshalTimeReal(rec[idxDownloadBegin : idxDownloadBegin+lenDownloadBegin])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal download period begin: %w", i, err)
+		}
+		r.SetDownloadPeriodBegin(downloadBegin)
+
+		// downloadPeriodEnd (4 bytes, TimeReal)
+		downloadEnd, err := opts.UnmarshalTimeReal(rec[idxDownloadEnd : idxDownloadEnd+lenDownloadEnd])
+		if err != nil {
+			return nil, fmt.Errorf("record %d: failed to unmarshal download period end: %w", i, err)
+		}
+		r.SetDownloadPeriodEnd(downloadEnd)
+
+		records[i] = r
+	}
+	target.SetRecords(records)
+
+	return target, nil
+}

--- a/internal/card/company_activity_data_test.go
+++ b/internal/card/company_activity_data_test.go
@@ -1,0 +1,167 @@
+package card
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// makeCompanyActivityRecord builds a 47-byte companyActivityRecord payload.
+//
+// Layout:
+//   - Byte  0:    companyActivityType (1 byte)
+//   - Bytes 1-4:  companyActivityTime (4 bytes, big-endian TimeReal)
+//   - Bytes 5-23: cardNumberInformation (19 bytes, zeroed)
+//   - Bytes 24-38: vehicleRegistrationInformation (15 bytes, zeroed)
+//   - Bytes 39-42: downloadPeriodBegin (4 bytes, big-endian TimeReal)
+//   - Bytes 43-46: downloadPeriodEnd (4 bytes, big-endian TimeReal)
+func makeCompanyActivityRecord(activityType byte, activityTimeSecs, beginSecs, endSecs uint32) []byte {
+	r := make([]byte, 47)
+	r[0] = activityType
+	binary.BigEndian.PutUint32(r[1:5], activityTimeSecs)
+	// cardNumberInformation (19 bytes): all zeros = valid FullCardNumber(18)+Generation(1)
+	// vehicleRegistrationInformation (15 bytes): all zeros
+	binary.BigEndian.PutUint32(r[39:43], beginSecs)
+	binary.BigEndian.PutUint32(r[43:47], endSecs)
+	return r
+}
+
+func TestUnmarshalCompanyActivityData(t *testing.T) {
+	t.Run("empty input error", func(t *testing.T) {
+		_, err := UnmarshalOptions{}.unmarshalCompanyActivityData([]byte{})
+		if err == nil {
+			t.Fatal("expected error for empty input, got nil")
+		}
+	})
+
+	t.Run("pointer only, zero records", func(t *testing.T) {
+		data := []byte{0x00, 0x00}
+		got, err := UnmarshalOptions{}.unmarshalCompanyActivityData(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 0 {
+			t.Errorf("NewestRecordIndex: got %d, want 0", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 0 {
+			t.Errorf("Records count: got %d, want 0", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("one record card-downloading", func(t *testing.T) {
+		// protocol_enum_value=1 → CARD_DOWNLOADING
+		rec := makeCompanyActivityRecord(0x01, 5000, 1000, 4000)
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalCompanyActivityData(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.GetRecords()) != 1 {
+			t.Fatalf("Records count: got %d, want 1", len(got.GetRecords()))
+		}
+		r := got.GetRecords()[0]
+		if r.GetCompanyActivityType() != ddv1.CompanyActivityType_CARD_DOWNLOADING {
+			t.Errorf("CompanyActivityType: got %v, want CARD_DOWNLOADING", r.GetCompanyActivityType())
+		}
+		if r.GetCompanyActivityTime().GetSeconds() != 5000 {
+			t.Errorf("CompanyActivityTime: got %d, want 5000", r.GetCompanyActivityTime().GetSeconds())
+		}
+		if r.GetDownloadPeriodBegin().GetSeconds() != 1000 {
+			t.Errorf("DownloadPeriodBegin: got %d, want 1000", r.GetDownloadPeriodBegin().GetSeconds())
+		}
+		if r.GetDownloadPeriodEnd().GetSeconds() != 4000 {
+			t.Errorf("DownloadPeriodEnd: got %d, want 4000", r.GetDownloadPeriodEnd().GetSeconds())
+		}
+	})
+
+	t.Run("two records", func(t *testing.T) {
+		rec1 := makeCompanyActivityRecord(0x01, 1000, 500, 900)  // CARD_DOWNLOADING
+		rec2 := makeCompanyActivityRecord(0x02, 2000, 1500, 1900) // VU_DOWNLOADING
+		data := append([]byte{0x00, 0x01}, rec1...)
+		data = append(data, rec2...)
+
+		got, err := UnmarshalOptions{}.unmarshalCompanyActivityData(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 1 {
+			t.Errorf("NewestRecordIndex: got %d, want 1", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 2 {
+			t.Fatalf("Records count: got %d, want 2", len(got.GetRecords()))
+		}
+		if got.GetRecords()[1].GetCompanyActivityType() != ddv1.CompanyActivityType_VU_DOWNLOADING {
+			t.Errorf("Record[1] CompanyActivityType: got %v, want VU_DOWNLOADING", got.GetRecords()[1].GetCompanyActivityType())
+		}
+	})
+
+	t.Run("truncated record returns error", func(t *testing.T) {
+		// 2-byte pointer + 30 bytes (not a multiple of 47)
+		data := make([]byte, 32)
+		_, err := UnmarshalOptions{}.unmarshalCompanyActivityData(data)
+		if err == nil {
+			t.Fatal("expected error for truncated record, got nil")
+		}
+	})
+}
+
+func TestCompanyActivityData_ParseRawDriverCardFile(t *testing.T) {
+	rec := makeCompanyActivityRecord(0x01, 8000, 6000, 7500) // CARD_DOWNLOADING
+	efData := append([]byte{0x00, 0x00}, rec...)
+
+	rawRec := &cardv1.RawCardFile_Record{}
+	rawRec.SetFile(cardv1.ElementaryFileType_EF_COMPANY_ACTIVITY_DATA)
+	rawRec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rawRec.SetContentType(cardv1.ContentType_DATA)
+	rawRec.SetValue(efData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rawRec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile: %v", err)
+	}
+	cad := cardFile.GetTachographG2().GetCompanyActivityData()
+	if cad == nil {
+		t.Fatal("CompanyActivityData is nil — EF_COMPANY_ACTIVITY_DATA not wired into switch")
+	}
+	if len(cad.GetRecords()) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(cad.GetRecords()))
+	}
+	if cad.GetRecords()[0].GetCompanyActivityType() != ddv1.CompanyActivityType_CARD_DOWNLOADING {
+		t.Errorf("CompanyActivityType: got %v, want CARD_DOWNLOADING", cad.GetRecords()[0].GetCompanyActivityType())
+	}
+}
+
+func TestCompanyActivityData_Fixtures(t *testing.T) {
+	hexdumpFiles, err := findHexdumpFiles(
+		cardv1.ElementaryFileType_EF_COMPANY_ACTIVITY_DATA,
+		ddv1.Generation_GENERATION_2,
+		cardv1.ContentType_DATA,
+	)
+	if err != nil {
+		t.Fatalf("failed to discover hexdump files: %v", err)
+	}
+	if len(hexdumpFiles) == 0 {
+		t.Skip("no hexdump fixtures found for EF_COMPANY_ACTIVITY_DATA GENERATION_2")
+	}
+	for _, hexdumpPath := range hexdumpFiles {
+		relPath := strings.TrimPrefix(hexdumpPath, "testdata/records/")
+		t.Run(strings.TrimSuffix(relPath, ".hexdump"), func(t *testing.T) {
+			data, err := readHexdump(hexdumpPath)
+			if err != nil {
+				t.Fatalf("failed to read hexdump: %v", err)
+			}
+			got, err := UnmarshalOptions{}.unmarshalCompanyActivityData(data)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			loadOrCreateGolden(t, got, goldenJSONPath(hexdumpPath))
+		})
+	}
+}

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -556,6 +556,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetApplicationIdentificationV2(appIdV2)
 
+		case cardv1.ElementaryFileType_EF_PLACES_AUTHENTICATION:
+			placesAuthentication, err := unmarshalOpts.unmarshalPlacesAuthentication(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetPlacesAuthentication(placesAuthentication)
+
 		case cardv1.ElementaryFileType_EF_BORDER_CROSSINGS:
 			borderCrossings, err := unmarshalOpts.unmarshalBorderCrossings(record.GetValue())
 			if err != nil {

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -568,6 +568,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetBorderCrossings(borderCrossings)
 
+		case cardv1.ElementaryFileType_EF_LOAD_UNLOAD_OPERATIONS:
+			loadUnloadOps, err := unmarshalOpts.unmarshalLoadUnloadOperations(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetLoadUnloadOperations(loadUnloadOps)
+
 		case cardv1.ElementaryFileType_EF_CARD_CERTIFICATE:
 			// Gen1: Card authentication certificate
 			// Only appears in Gen1 DF (Tachograph)

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -616,6 +616,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetLoadTypeEntries(loadTypeEntries)
 
+		case cardv1.ElementaryFileType_EF_COMPANY_ACTIVITY_DATA:
+			companyActivityData, err := unmarshalOpts.unmarshalCompanyActivityData(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetCompanyActivityData(companyActivityData)
+
 		case cardv1.ElementaryFileType_EF_CARD_CERTIFICATE:
 			// Gen1: Card authentication certificate
 			// Only appears in Gen1 DF (Tachograph)

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -580,6 +580,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetLoadUnloadOperations(loadUnloadOps)
 
+		case cardv1.ElementaryFileType_EF_LOAD_TYPE_ENTRIES:
+			loadTypeEntries, err := unmarshalOpts.unmarshalLoadTypeEntries(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetLoadTypeEntries(loadTypeEntries)
+
 		case cardv1.ElementaryFileType_EF_CARD_CERTIFICATE:
 			// Gen1: Card authentication certificate
 			// Only appears in Gen1 DF (Tachograph)

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -556,6 +556,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetApplicationIdentificationV2(appIdV2)
 
+		case cardv1.ElementaryFileType_EF_BORDER_CROSSINGS:
+			borderCrossings, err := unmarshalOpts.unmarshalBorderCrossings(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetBorderCrossings(borderCrossings)
+
 		case cardv1.ElementaryFileType_EF_CARD_CERTIFICATE:
 			// Gen1: Card authentication certificate
 			// Only appears in Gen1 DF (Tachograph)

--- a/internal/card/driver_card_file.go
+++ b/internal/card/driver_card_file.go
@@ -568,6 +568,18 @@ func (opts ParseOptions) ParseRawDriverCardFile(input *cardv1.RawCardFile) (*car
 			}
 			tachographG2DF.SetPlacesAuthentication(placesAuthentication)
 
+		case cardv1.ElementaryFileType_EF_GNSS_PLACES_AUTHENTICATION:
+			gnssPlacesAuthentication, err := unmarshalOpts.unmarshalGnssPlacesAuthentication(record.GetValue())
+			if err != nil {
+				return nil, err
+			}
+
+			// Only Gen2
+			if tachographG2DF == nil {
+				tachographG2DF = &cardv1.DriverCardFile_TachographG2{}
+			}
+			tachographG2DF.SetGnssPlacesAuthentication(gnssPlacesAuthentication)
+
 		case cardv1.ElementaryFileType_EF_BORDER_CROSSINGS:
 			borderCrossings, err := unmarshalOpts.unmarshalBorderCrossings(record.GetValue())
 			if err != nil {

--- a/internal/card/driver_card_file_test.go
+++ b/internal/card/driver_card_file_test.go
@@ -1,0 +1,79 @@
+package card
+
+import (
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// TestParseRawDriverCardFile_BorderCrossings verifies that EF_BORDER_CROSSINGS records
+// are wired into ParseRawDriverCardFile and propagated to TachographG2.border_crossings.
+//
+// Uses the same synthetic byte layout as TestUnmarshalBorderCrossings_Synthetic:
+//
+//	1-byte pointer (0x00) + 1 record (17 bytes):
+//	  [0x0F]               country_left  = Spain
+//	  [0x11]               country_entered = France
+//	  [00 00 00 0A]        GNSS timestamp = 10 s since midnight 1970-01-01
+//	  [00]                 GNSS accuracy
+//	  [00 00 00]           GNSS latitude  = 0
+//	  [00 00 00]           GNSS longitude = 0
+//	  [00]                 authentication status = NOT_AUTHENTICATED
+//	  [00 00 64]           odometer = 100 km
+func TestParseRawDriverCardFile_BorderCrossings(t *testing.T) {
+	borderCrossingsData := []byte{
+		0x00,                               // pointer: newest record index = 0
+		0x0F, 0x11,                         // country_left = Spain, country_entered = France
+		0x00, 0x00, 0x00, 0x0A,            // GNSS timestamp (4 bytes)
+		0x00,                               // GNSS accuracy
+		0x00, 0x00, 0x00,                  // GNSS latitude
+		0x00, 0x00, 0x00,                  // GNSS longitude
+		0x00,                               // GNSS authentication status = NOT_AUTHENTICATED
+		0x00, 0x00, 0x64,                  // odometer = 100 km
+	}
+
+	rec := &cardv1.RawCardFile_Record{}
+	rec.SetFile(cardv1.ElementaryFileType_EF_BORDER_CROSSINGS)
+	rec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rec.SetContentType(cardv1.ContentType_DATA)
+	rec.SetValue(borderCrossingsData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile returned unexpected error: %v", err)
+	}
+
+	g2 := cardFile.GetTachographG2()
+	if g2 == nil {
+		t.Fatal("TachographG2 is nil — EF_BORDER_CROSSINGS was not wired into the switch")
+	}
+
+	bc := g2.GetBorderCrossings()
+	if bc == nil {
+		t.Fatal("BorderCrossings is nil — EF_BORDER_CROSSINGS case is missing from the switch")
+	}
+
+	if got := bc.GetNewestRecordIndex(); got != 0 {
+		t.Errorf("NewestRecordIndex: got %d, want 0", got)
+	}
+
+	records := bc.GetRecords()
+	if len(records) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(records))
+	}
+
+	r := records[0]
+	if got, want := r.GetCountryLeft(), ddv1.NationNumeric_SPAIN; got != want {
+		t.Errorf("CountryLeft: got %v, want %v", got, want)
+	}
+	if got, want := r.GetCountryEntered(), ddv1.NationNumeric_FRANCE; got != want {
+		t.Errorf("CountryEntered: got %v, want %v", got, want)
+	}
+	if got, want := r.GetVehicleOdometerKm(), int32(100); got != want {
+		t.Errorf("VehicleOdometerKm: got %d, want %d", got, want)
+	}
+}

--- a/internal/card/gnss_places.go
+++ b/internal/card/gnss_places.go
@@ -142,7 +142,9 @@ func (opts UnmarshalOptions) unmarshalGNSSAccumulatedDrivingRecord(data []byte) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal vehicle odometer: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(odometer))
+	if odometer != nil {
+		record.SetVehicleOdometerKm(*odometer)
+	}
 
 	return &record, nil
 }

--- a/internal/card/gnss_places_authentication.go
+++ b/internal/card/gnss_places_authentication.go
@@ -1,0 +1,66 @@
+package card
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+)
+
+// unmarshalGnssPlacesAuthentication parses the EF_GNSS_Places_Authentication file.
+//
+// The data type `GNSSAuthAccumulatedDriving` is specified in the Data Dictionary, Section 2.79a.
+//
+// ASN.1 Definition:
+//
+//	GNSSAuthAccumulatedDriving ::= SEQUENCE {
+//	    gnssAuthADPointerNewestRecord INTEGER(0..NoOfGNSSADRecords -1),
+//	    gnssAuthStatusADRecords SET SIZE(NoOfGNSSADRecords) OF GNSSAuthStatusADRecord
+//	}
+//
+// Binary Layout:
+//   - Bytes 0-1: gnssAuthADPointerNewestRecord (2 bytes, big-endian)
+//   - Bytes 2..N: Array of GNSSAuthStatusADRecord (5 bytes each)
+//
+// GNSSAuthStatusADRecord has the same binary layout as PlaceAuthStatusRecord:
+// 4B TimeReal + 1B PositionAuthenticationStatus.
+func (opts UnmarshalOptions) unmarshalGnssPlacesAuthentication(data []byte) (*cardv1.GnssPlacesAuthentication, error) {
+	const (
+		lenPointer = 2
+		lenRecord  = 5
+	)
+
+	if len(data) < lenPointer {
+		return nil, fmt.Errorf("data too short for GNSSAuthAccumulatedDriving: got %d, want at least %d", len(data), lenPointer)
+	}
+
+	recordsData := data[lenPointer:]
+	if len(recordsData)%lenRecord != 0 {
+		return nil, fmt.Errorf("invalid data length for GNSSAuthAccumulatedDriving records: %d is not a multiple of %d", len(recordsData), lenRecord)
+	}
+
+	newestRecordIndex := int32(binary.BigEndian.Uint16(data[0:lenPointer]))
+
+	target := &cardv1.GnssPlacesAuthentication{}
+	target.SetNewestRecordIndex(newestRecordIndex)
+
+	count := len(recordsData) / lenRecord
+	records := make([]*cardv1.GnssPlacesAuthentication_Record, count)
+
+	for i := 0; i < count; i++ {
+		start := i * lenRecord
+		// GNSSAuthStatusADRecord has the same layout as PlaceAuthStatusRecord.
+		ddRecord, err := opts.UnmarshalPlaceAuthStatusRecord(recordsData[start : start+lenRecord])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal GNSS auth status record %d: %w", i, err)
+		}
+
+		r := &cardv1.GnssPlacesAuthentication_Record{}
+		r.SetTimestamp(ddRecord.GetEntryTime())
+		r.SetAuthenticationStatus(ddRecord.GetAuthenticationStatus())
+		records[i] = r
+	}
+	target.SetRecords(records)
+
+	return target, nil
+}

--- a/internal/card/gnss_places_authentication.go
+++ b/internal/card/gnss_places_authentication.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
 )
 
 // unmarshalGnssPlacesAuthentication parses the EF_GNSS_Places_Authentication file.
@@ -63,4 +64,29 @@ func (opts UnmarshalOptions) unmarshalGnssPlacesAuthentication(data []byte) (*ca
 	target.SetRecords(records)
 
 	return target, nil
+}
+
+// MarshalGnssPlacesAuthentication marshals the EF_GNSS_Places_Authentication file.
+func (opts MarshalOptions) MarshalGnssPlacesAuthentication(msg *cardv1.GnssPlacesAuthentication) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	var dst []byte
+	dst = binary.BigEndian.AppendUint16(dst, uint16(msg.GetNewestRecordIndex()))
+
+	for i, record := range msg.GetRecords() {
+		// GNSSAuthStatusADRecord has the same layout as PlaceAuthStatusRecord.
+		ddRecord := &ddv1.PlaceAuthStatusRecord{}
+		ddRecord.SetEntryTime(record.GetTimestamp())
+		ddRecord.SetAuthenticationStatus(record.GetAuthenticationStatus())
+
+		b, err := opts.MarshalPlaceAuthStatusRecord(ddRecord)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal GNSS auth status record %d: %w", i, err)
+		}
+		dst = append(dst, b...)
+	}
+
+	return dst, nil
 }

--- a/internal/card/gnss_places_authentication_test.go
+++ b/internal/card/gnss_places_authentication_test.go
@@ -1,0 +1,137 @@
+package card
+
+import (
+	"strings"
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+func TestUnmarshalGnssPlacesAuthentication(t *testing.T) {
+	t.Run("empty input error", func(t *testing.T) {
+		_, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication([]byte{})
+		if err == nil {
+			t.Fatal("expected error for empty input, got nil")
+		}
+	})
+
+	t.Run("pointer only, zero records", func(t *testing.T) {
+		data := []byte{0x00, 0x00}
+		got, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 0 {
+			t.Errorf("NewestRecordIndex: got %d, want 0", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 0 {
+			t.Errorf("Records count: got %d, want 0", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("one record authenticated", func(t *testing.T) {
+		// makePlaceAuthStatusRecord reused: 4B timestamp + 1B authStatus
+		rec := makePlaceAuthStatusRecord(9000, 0x01) // AUTHENTICATED
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.GetRecords()) != 1 {
+			t.Fatalf("Records count: got %d, want 1", len(got.GetRecords()))
+		}
+		r := got.GetRecords()[0]
+		if r.GetTimestamp().GetSeconds() != 9000 {
+			t.Errorf("Timestamp: got %d, want 9000", r.GetTimestamp().GetSeconds())
+		}
+		if r.GetAuthenticationStatus() != ddv1.PositionAuthenticationStatus_AUTHENTICATED {
+			t.Errorf("AuthenticationStatus: got %v, want AUTHENTICATED", r.GetAuthenticationStatus())
+		}
+	})
+
+	t.Run("multiple records", func(t *testing.T) {
+		rec1 := makePlaceAuthStatusRecord(1000, 0x01) // AUTHENTICATED
+		rec2 := makePlaceAuthStatusRecord(2000, 0x00) // NOT_AUTHENTICATED
+		data := append([]byte{0x00, 0x01}, rec1...)
+		data = append(data, rec2...)
+
+		got, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 1 {
+			t.Errorf("NewestRecordIndex: got %d, want 1", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 2 {
+			t.Fatalf("Records count: got %d, want 2", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("truncated record returns error", func(t *testing.T) {
+		// 2-byte pointer + 3 bytes (not a multiple of 5)
+		data := make([]byte, 5)
+		_, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication(data)
+		if err == nil {
+			t.Fatal("expected error for truncated record, got nil")
+		}
+	})
+}
+
+func TestGnssPlacesAuthentication_ParseRawDriverCardFile(t *testing.T) {
+	rec := makePlaceAuthStatusRecord(4800, 0x01) // AUTHENTICATED
+	efData := append([]byte{0x00, 0x00}, rec...)
+
+	rawRec := &cardv1.RawCardFile_Record{}
+	rawRec.SetFile(cardv1.ElementaryFileType_EF_GNSS_PLACES_AUTHENTICATION)
+	rawRec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rawRec.SetContentType(cardv1.ContentType_DATA)
+	rawRec.SetValue(efData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rawRec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile: %v", err)
+	}
+	gpa := cardFile.GetTachographG2().GetGnssPlacesAuthentication()
+	if gpa == nil {
+		t.Fatal("GnssPlacesAuthentication is nil — EF_GNSS_PLACES_AUTHENTICATION not wired into switch")
+	}
+	if len(gpa.GetRecords()) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(gpa.GetRecords()))
+	}
+	if gpa.GetRecords()[0].GetAuthenticationStatus() != ddv1.PositionAuthenticationStatus_AUTHENTICATED {
+		t.Errorf("AuthenticationStatus: got %v, want AUTHENTICATED", gpa.GetRecords()[0].GetAuthenticationStatus())
+	}
+}
+
+func TestGnssPlacesAuthentication_Fixtures(t *testing.T) {
+	hexdumpFiles, err := findHexdumpFiles(
+		cardv1.ElementaryFileType_EF_GNSS_PLACES_AUTHENTICATION,
+		ddv1.Generation_GENERATION_2,
+		cardv1.ContentType_DATA,
+	)
+	if err != nil {
+		t.Fatalf("failed to discover hexdump files: %v", err)
+	}
+	if len(hexdumpFiles) == 0 {
+		t.Skip("no hexdump fixtures found for EF_GNSS_PLACES_AUTHENTICATION GENERATION_2")
+	}
+	for _, hexdumpPath := range hexdumpFiles {
+		relPath := strings.TrimPrefix(hexdumpPath, "testdata/records/")
+		t.Run(strings.TrimSuffix(relPath, ".hexdump"), func(t *testing.T) {
+			data, err := readHexdump(hexdumpPath)
+			if err != nil {
+				t.Fatalf("failed to read hexdump: %v", err)
+			}
+			got, err := UnmarshalOptions{}.unmarshalGnssPlacesAuthentication(data)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			loadOrCreateGolden(t, got, goldenJSONPath(hexdumpPath))
+		})
+	}
+}

--- a/internal/card/load_type_entries.go
+++ b/internal/card/load_type_entries.go
@@ -1,0 +1,62 @@
+package card
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+)
+
+// unmarshalLoadTypeEntries parses the EF_Load_Type_Entries file.
+//
+// The data type `CardLoadTypeEntries` is specified in the Data Dictionary, Section 2.24a.
+//
+// ASN.1 Definition:
+//
+//	CardLoadTypeEntries ::= SEQUENCE {
+//	    loadTypeEntryPointerNewestRecord INTEGER(0..NoOfLoadTypeEntryRecords-1),
+//	    cardLoadTypeEntryRecords SET SIZE(NoOfLoadTypeEntryRecords) OF CardLoadTypeEntryRecord
+//	}
+//
+// Binary Layout:
+//   - Bytes 0-1: loadTypeEntryPointerNewestRecord (2 bytes, big-endian)
+//   - Bytes 2..N: Array of CardLoadTypeEntryRecord (5 bytes each)
+func (opts UnmarshalOptions) unmarshalLoadTypeEntries(data []byte) (*cardv1.LoadTypeEntries, error) {
+	const (
+		lenPointer = 2
+		lenRecord  = 5
+	)
+
+	if len(data) < lenPointer {
+		return nil, fmt.Errorf("data too short for CardLoadTypeEntries: got %d, want at least %d", len(data), lenPointer)
+	}
+
+	recordsData := data[lenPointer:]
+	if len(recordsData)%lenRecord != 0 {
+		return nil, fmt.Errorf("invalid data length for CardLoadTypeEntries records: %d is not a multiple of %d", len(recordsData), lenRecord)
+	}
+
+	newestRecordIndex := int32(binary.BigEndian.Uint16(data[0:lenPointer]))
+
+	target := &cardv1.LoadTypeEntries{}
+	target.SetNewestRecordIndex(newestRecordIndex)
+
+	count := len(recordsData) / lenRecord
+	records := make([]*cardv1.LoadTypeEntries_Record, count)
+
+	for i := 0; i < count; i++ {
+		start := i * lenRecord
+		ddRecord, err := opts.UnmarshalCardLoadTypeEntryRecord(recordsData[start : start+lenRecord])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal load type entry record %d: %w", i, err)
+		}
+
+		r := &cardv1.LoadTypeEntries_Record{}
+		r.SetTimestamp(ddRecord.GetTimeStamp())
+		r.SetLoadTypeEntered(ddRecord.GetLoadTypeEntered())
+		records[i] = r
+	}
+	target.SetRecords(records)
+
+	return target, nil
+}

--- a/internal/card/load_type_entries.go
+++ b/internal/card/load_type_entries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
 )
 
 // unmarshalLoadTypeEntries parses the EF_Load_Type_Entries file.
@@ -59,4 +60,28 @@ func (opts UnmarshalOptions) unmarshalLoadTypeEntries(data []byte) (*cardv1.Load
 	target.SetRecords(records)
 
 	return target, nil
+}
+
+// MarshalLoadTypeEntries marshals the EF_Load_Type_Entries file.
+func (opts MarshalOptions) MarshalLoadTypeEntries(msg *cardv1.LoadTypeEntries) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	var dst []byte
+	dst = binary.BigEndian.AppendUint16(dst, uint16(msg.GetNewestRecordIndex()))
+
+	for i, record := range msg.GetRecords() {
+		ddRecord := &ddv1.CardLoadTypeEntryRecord{}
+		ddRecord.SetTimeStamp(record.GetTimestamp())
+		ddRecord.SetLoadTypeEntered(record.GetLoadTypeEntered())
+
+		b, err := opts.MarshalCardLoadTypeEntryRecord(ddRecord)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal load type entry record %d: %w", i, err)
+		}
+		dst = append(dst, b...)
+	}
+
+	return dst, nil
 }

--- a/internal/card/load_type_entries_test.go
+++ b/internal/card/load_type_entries_test.go
@@ -1,0 +1,150 @@
+package card
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// makeLoadTypeRecord builds a 5-byte CardLoadTypeEntryRecord payload.
+//
+// Layout: 4B timestamp | 1B loadType
+func makeLoadTypeRecord(timestampSecs uint32, loadType byte) []byte {
+	r := make([]byte, 5)
+	binary.BigEndian.PutUint32(r[0:4], timestampSecs)
+	r[4] = loadType
+	return r
+}
+
+func TestUnmarshalLoadTypeEntries(t *testing.T) {
+	t.Run("empty input error", func(t *testing.T) {
+		_, err := UnmarshalOptions{}.unmarshalLoadTypeEntries([]byte{})
+		if err == nil {
+			t.Fatal("expected error for empty input, got nil")
+		}
+	})
+
+	t.Run("pointer only, zero records", func(t *testing.T) {
+		data := []byte{0x00, 0x00}
+		got, err := UnmarshalOptions{}.unmarshalLoadTypeEntries(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 0 {
+			t.Errorf("NewestRecordIndex: got %d, want 0", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 0 {
+			t.Errorf("Records count: got %d, want 0", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("one record", func(t *testing.T) {
+		// loadType byte 0x01 → GOODS (protocol_enum_value=1)
+		rec := makeLoadTypeRecord(3000, 0x01)
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalLoadTypeEntries(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.GetRecords()) != 1 {
+			t.Fatalf("Records count: got %d, want 1", len(got.GetRecords()))
+		}
+		r := got.GetRecords()[0]
+		if r.GetTimestamp().GetSeconds() != 3000 {
+			t.Errorf("Timestamp: got %d, want 3000", r.GetTimestamp().GetSeconds())
+		}
+		if r.GetLoadTypeEntered() != ddv1.LoadType_GOODS {
+			t.Errorf("LoadTypeEntered: got %v, want GOODS", r.GetLoadTypeEntered())
+		}
+	})
+
+	t.Run("multiple records", func(t *testing.T) {
+		rec1 := makeLoadTypeRecord(1000, 0x01) // GOODS
+		rec2 := makeLoadTypeRecord(2000, 0x02) // PASSENGERS
+		rec3 := makeLoadTypeRecord(3000, 0x00) // NOT_DEFINED
+		data := append([]byte{0x00, 0x02}, rec1...)
+		data = append(data, rec2...)
+		data = append(data, rec3...)
+
+		got, err := UnmarshalOptions{}.unmarshalLoadTypeEntries(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 2 {
+			t.Errorf("NewestRecordIndex: got %d, want 2", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 3 {
+			t.Fatalf("Records count: got %d, want 3", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("truncated record returns error", func(t *testing.T) {
+		// 2-byte pointer + 3 bytes (not a multiple of 5)
+		data := make([]byte, 5)
+		_, err := UnmarshalOptions{}.unmarshalLoadTypeEntries(data)
+		if err == nil {
+			t.Fatal("expected error for truncated record, got nil")
+		}
+	})
+}
+
+func TestLoadTypeEntries_ParseRawDriverCardFile(t *testing.T) {
+	rec := makeLoadTypeRecord(5000, 0x02) // PASSENGERS
+	efData := append([]byte{0x00, 0x00}, rec...)
+
+	rawRec := &cardv1.RawCardFile_Record{}
+	rawRec.SetFile(cardv1.ElementaryFileType_EF_LOAD_TYPE_ENTRIES)
+	rawRec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rawRec.SetContentType(cardv1.ContentType_DATA)
+	rawRec.SetValue(efData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rawRec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile: %v", err)
+	}
+	lt := cardFile.GetTachographG2().GetLoadTypeEntries()
+	if lt == nil {
+		t.Fatal("LoadTypeEntries is nil — EF_LOAD_TYPE_ENTRIES not wired into switch")
+	}
+	if len(lt.GetRecords()) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(lt.GetRecords()))
+	}
+	if lt.GetRecords()[0].GetLoadTypeEntered() != ddv1.LoadType_PASSENGERS {
+		t.Errorf("LoadTypeEntered: got %v, want PASSENGERS", lt.GetRecords()[0].GetLoadTypeEntered())
+	}
+}
+
+func TestLoadTypeEntries_Fixtures(t *testing.T) {
+	hexdumpFiles, err := findHexdumpFiles(
+		cardv1.ElementaryFileType_EF_LOAD_TYPE_ENTRIES,
+		ddv1.Generation_GENERATION_2,
+		cardv1.ContentType_DATA,
+	)
+	if err != nil {
+		t.Fatalf("failed to discover hexdump files: %v", err)
+	}
+	if len(hexdumpFiles) == 0 {
+		t.Skip("no hexdump fixtures found for EF_LOAD_TYPE_ENTRIES GENERATION_2")
+	}
+	for _, hexdumpPath := range hexdumpFiles {
+		relPath := strings.TrimPrefix(hexdumpPath, "testdata/records/")
+		t.Run(strings.TrimSuffix(relPath, ".hexdump"), func(t *testing.T) {
+			data, err := readHexdump(hexdumpPath)
+			if err != nil {
+				t.Fatalf("failed to read hexdump: %v", err)
+			}
+			got, err := UnmarshalOptions{}.unmarshalLoadTypeEntries(data)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			loadOrCreateGolden(t, got, goldenJSONPath(hexdumpPath))
+		})
+	}
+}

--- a/internal/card/load_unload_operations.go
+++ b/internal/card/load_unload_operations.go
@@ -1,0 +1,66 @@
+package card
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+)
+
+// unmarshalLoadUnloadOperations parses the EF_Load_Unload_Operations file.
+//
+// The data type `CardLoadUnloadOperations` is specified in the Data Dictionary, Section 2.24c.
+//
+// ASN.1 Definition:
+//
+//	CardLoadUnloadOperations ::= SEQUENCE {
+//	    loadUnloadPointerNewestRecord INTEGER(0..NoOfLoadUnloadRecords -1),
+//	    cardLoadUnloadRecords SET SIZE (NoOfLoadUnloadRecords) OF CardLoadUnloadRecord
+//	}
+//
+// Binary Layout:
+//   - Bytes 0-1: loadUnloadPointerNewestRecord (2 bytes, big-endian)
+//   - Bytes 2..N: Array of CardLoadUnloadRecord (20 bytes each)
+func (opts UnmarshalOptions) unmarshalLoadUnloadOperations(data []byte) (*cardv1.LoadUnloadOperations, error) {
+	const (
+		lenPointer = 2
+		lenRecord  = 20
+	)
+
+	if len(data) < lenPointer {
+		return nil, fmt.Errorf("data too short for CardLoadUnloadOperations: got %d, want at least %d", len(data), lenPointer)
+	}
+
+	recordsData := data[lenPointer:]
+	if len(recordsData)%lenRecord != 0 {
+		return nil, fmt.Errorf("invalid data length for CardLoadUnloadOperations records: %d is not a multiple of %d", len(recordsData), lenRecord)
+	}
+
+	newestRecordIndex := int32(binary.BigEndian.Uint16(data[0:lenPointer]))
+
+	target := &cardv1.LoadUnloadOperations{}
+	target.SetNewestRecordIndex(newestRecordIndex)
+
+	count := len(recordsData) / lenRecord
+	records := make([]*cardv1.LoadUnloadOperations_Record, count)
+
+	for i := 0; i < count; i++ {
+		start := i * lenRecord
+		ddRecord, err := opts.UnmarshalCardLoadUnloadRecord(recordsData[start : start+lenRecord])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal load/unload record %d: %w", i, err)
+		}
+
+		r := &cardv1.LoadUnloadOperations_Record{}
+		r.SetTimestamp(ddRecord.GetTimeStamp())
+		r.SetOperationType(ddRecord.GetOperationType())
+		r.SetGnssPlaceAuthRecord(ddRecord.GetGnssPlaceAuthRecord())
+		if ddRecord.HasVehicleOdometerKm() {
+			r.SetVehicleOdometerKm(ddRecord.GetVehicleOdometerKm())
+		}
+		records[i] = r
+	}
+	target.SetRecords(records)
+
+	return target, nil
+}

--- a/internal/card/load_unload_operations.go
+++ b/internal/card/load_unload_operations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
 )
 
 // unmarshalLoadUnloadOperations parses the EF_Load_Unload_Operations file.
@@ -63,4 +64,32 @@ func (opts UnmarshalOptions) unmarshalLoadUnloadOperations(data []byte) (*cardv1
 	target.SetRecords(records)
 
 	return target, nil
+}
+
+// MarshalLoadUnloadOperations marshals the EF_Load_Unload_Operations file.
+func (opts MarshalOptions) MarshalLoadUnloadOperations(msg *cardv1.LoadUnloadOperations) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	var dst []byte
+	dst = binary.BigEndian.AppendUint16(dst, uint16(msg.GetNewestRecordIndex()))
+
+	for i, record := range msg.GetRecords() {
+		ddRecord := &ddv1.CardLoadUnloadRecord{}
+		ddRecord.SetTimeStamp(record.GetTimestamp())
+		ddRecord.SetOperationType(record.GetOperationType())
+		ddRecord.SetGnssPlaceAuthRecord(record.GetGnssPlaceAuthRecord())
+		if record.HasVehicleOdometerKm() {
+			ddRecord.SetVehicleOdometerKm(record.GetVehicleOdometerKm())
+		}
+
+		b, err := opts.MarshalCardLoadUnloadRecord(ddRecord)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal load/unload record %d: %w", i, err)
+		}
+		dst = append(dst, b...)
+	}
+
+	return dst, nil
 }

--- a/internal/card/load_unload_operations_test.go
+++ b/internal/card/load_unload_operations_test.go
@@ -1,0 +1,171 @@
+package card
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// makeLoadUnloadRecord builds a 20-byte CardLoadUnloadRecord payload.
+//
+// Layout: 4B timestamp | 1B operationType | 12B gnssPlaceAuthRecord | 3B odometer
+func makeLoadUnloadRecord(timestampSecs uint32, opType byte, odometer [3]byte) []byte {
+	r := make([]byte, 20)
+	binary.BigEndian.PutUint32(r[0:4], timestampSecs)
+	r[4] = opType
+	// gnssPlaceAuthRecord (12 bytes): timestamp(4) accuracy(1) lat(3) lon(3) authStatus(1)
+	binary.BigEndian.PutUint32(r[5:9], 0)
+	r[9] = 0x00
+	copy(r[10:13], []byte{0x00, 0x00, 0x00})
+	copy(r[13:16], []byte{0x00, 0x00, 0x00})
+	r[16] = 0x00
+	copy(r[17:20], odometer[:])
+	return r
+}
+
+func TestUnmarshalLoadUnloadOperations(t *testing.T) {
+	t.Run("empty input error", func(t *testing.T) {
+		_, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations([]byte{})
+		if err == nil {
+			t.Fatal("expected error for empty input, got nil")
+		}
+	})
+
+	t.Run("pointer only, zero records", func(t *testing.T) {
+		data := []byte{0x00, 0x00}
+		got, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 0 {
+			t.Errorf("NewestRecordIndex: got %d, want 0", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 0 {
+			t.Errorf("Records count: got %d, want 0", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("one record", func(t *testing.T) {
+		rec := makeLoadUnloadRecord(1000, 0x01, [3]byte{0x00, 0x00, 0x64}) // op=LOAD, 100 km
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.GetRecords()) != 1 {
+			t.Fatalf("Records count: got %d, want 1", len(got.GetRecords()))
+		}
+		r := got.GetRecords()[0]
+		if r.GetTimestamp().GetSeconds() != 1000 {
+			t.Errorf("Timestamp: got %d, want 1000", r.GetTimestamp().GetSeconds())
+		}
+		if r.GetOperationType() != ddv1.OperationType_LOAD_OPERATION {
+			t.Errorf("OperationType: got %v, want LOAD_OPERATION", r.GetOperationType())
+		}
+		if r.GetVehicleOdometerKm() != 100 {
+			t.Errorf("VehicleOdometerKm: got %d, want 100", r.GetVehicleOdometerKm())
+		}
+	})
+
+	t.Run("two records", func(t *testing.T) {
+		rec1 := makeLoadUnloadRecord(500, 0x01, [3]byte{0x00, 0x00, 0x0A})
+		rec2 := makeLoadUnloadRecord(600, 0x02, [3]byte{0x00, 0x00, 0x14})
+		data := append([]byte{0x00, 0x01}, rec1...)
+		data = append(data, rec2...)
+
+		got, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 1 {
+			t.Errorf("NewestRecordIndex: got %d, want 1", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 2 {
+			t.Fatalf("Records count: got %d, want 2", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("truncated record returns error", func(t *testing.T) {
+		// 2-byte pointer + 15 bytes (not a multiple of 20)
+		data := make([]byte, 17)
+		_, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+		if err == nil {
+			t.Fatal("expected error for truncated record, got nil")
+		}
+	})
+
+	t.Run("sentinel odometer 0xFFFFFF leaves field unset", func(t *testing.T) {
+		rec := makeLoadUnloadRecord(1000, 0x01, [3]byte{0xFF, 0xFF, 0xFF})
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		r := got.GetRecords()[0]
+		if r.HasVehicleOdometerKm() {
+			t.Errorf("VehicleOdometerKm should be unset for sentinel 0xFFFFFF, got %d", r.GetVehicleOdometerKm())
+		}
+	})
+}
+
+func TestLoadUnloadOperations_ParseRawDriverCardFile(t *testing.T) {
+	rec := makeLoadUnloadRecord(2000, 0x01, [3]byte{0x00, 0x03, 0xE8}) // 1000 km
+	efData := append([]byte{0x00, 0x00}, rec...)
+
+	rawRec := &cardv1.RawCardFile_Record{}
+	rawRec.SetFile(cardv1.ElementaryFileType_EF_LOAD_UNLOAD_OPERATIONS)
+	rawRec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rawRec.SetContentType(cardv1.ContentType_DATA)
+	rawRec.SetValue(efData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rawRec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile: %v", err)
+	}
+	lu := cardFile.GetTachographG2().GetLoadUnloadOperations()
+	if lu == nil {
+		t.Fatal("LoadUnloadOperations is nil — EF_LOAD_UNLOAD_OPERATIONS not wired into switch")
+	}
+	if len(lu.GetRecords()) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(lu.GetRecords()))
+	}
+	if lu.GetRecords()[0].GetVehicleOdometerKm() != 1000 {
+		t.Errorf("VehicleOdometerKm: got %d, want 1000", lu.GetRecords()[0].GetVehicleOdometerKm())
+	}
+}
+
+func TestLoadUnloadOperations_Fixtures(t *testing.T) {
+	hexdumpFiles, err := findHexdumpFiles(
+		cardv1.ElementaryFileType_EF_LOAD_UNLOAD_OPERATIONS,
+		ddv1.Generation_GENERATION_2,
+		cardv1.ContentType_DATA,
+	)
+	if err != nil {
+		t.Fatalf("failed to discover hexdump files: %v", err)
+	}
+	if len(hexdumpFiles) == 0 {
+		t.Skip("no hexdump fixtures found for EF_LOAD_UNLOAD_OPERATIONS GENERATION_2")
+	}
+	for _, hexdumpPath := range hexdumpFiles {
+		relPath := strings.TrimPrefix(hexdumpPath, "testdata/records/")
+		t.Run(strings.TrimSuffix(relPath, ".hexdump"), func(t *testing.T) {
+			data, err := readHexdump(hexdumpPath)
+			if err != nil {
+				t.Fatalf("failed to read hexdump: %v", err)
+			}
+			got, err := UnmarshalOptions{}.unmarshalLoadUnloadOperations(data)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			loadOrCreateGolden(t, got, goldenJSONPath(hexdumpPath))
+		})
+	}
+}

--- a/internal/card/places_authentication.go
+++ b/internal/card/places_authentication.go
@@ -1,0 +1,62 @@
+package card
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+)
+
+// unmarshalPlacesAuthentication parses the EF_Places_Authentication file.
+//
+// The data type `CardPlaceAuthDailyWorkPeriod` is specified in the Data Dictionary, Section 2.26a.
+//
+// ASN.1 Definition:
+//
+//	CardPlaceAuthDailyWorkPeriod ::= SEQUENCE {
+//	    placeAuthPointerNewestRecord INTEGER(0..NoOfCardPlaceRecords -1),
+//	    placeAuthStatusRecords SET SIZE(NoOfCardPlaceRecords) OF PlaceAuthStatusRecord
+//	}
+//
+// Binary Layout:
+//   - Bytes 0-1: placeAuthPointerNewestRecord (2 bytes, big-endian)
+//   - Bytes 2..N: Array of PlaceAuthStatusRecord (5 bytes each)
+func (opts UnmarshalOptions) unmarshalPlacesAuthentication(data []byte) (*cardv1.PlacesAuthentication, error) {
+	const (
+		lenPointer = 2
+		lenRecord  = 5
+	)
+
+	if len(data) < lenPointer {
+		return nil, fmt.Errorf("data too short for CardPlaceAuthDailyWorkPeriod: got %d, want at least %d", len(data), lenPointer)
+	}
+
+	recordsData := data[lenPointer:]
+	if len(recordsData)%lenRecord != 0 {
+		return nil, fmt.Errorf("invalid data length for CardPlaceAuthDailyWorkPeriod records: %d is not a multiple of %d", len(recordsData), lenRecord)
+	}
+
+	newestRecordIndex := int32(binary.BigEndian.Uint16(data[0:lenPointer]))
+
+	target := &cardv1.PlacesAuthentication{}
+	target.SetNewestRecordIndex(newestRecordIndex)
+
+	count := len(recordsData) / lenRecord
+	records := make([]*cardv1.PlacesAuthentication_Record, count)
+
+	for i := 0; i < count; i++ {
+		start := i * lenRecord
+		ddRecord, err := opts.UnmarshalPlaceAuthStatusRecord(recordsData[start : start+lenRecord])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal place auth status record %d: %w", i, err)
+		}
+
+		r := &cardv1.PlacesAuthentication_Record{}
+		r.SetEntryTime(ddRecord.GetEntryTime())
+		r.SetAuthenticationStatus(ddRecord.GetAuthenticationStatus())
+		records[i] = r
+	}
+	target.SetRecords(records)
+
+	return target, nil
+}

--- a/internal/card/places_authentication.go
+++ b/internal/card/places_authentication.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
 )
 
 // unmarshalPlacesAuthentication parses the EF_Places_Authentication file.
@@ -59,4 +60,28 @@ func (opts UnmarshalOptions) unmarshalPlacesAuthentication(data []byte) (*cardv1
 	target.SetRecords(records)
 
 	return target, nil
+}
+
+// MarshalPlacesAuthentication marshals the EF_Places_Authentication file.
+func (opts MarshalOptions) MarshalPlacesAuthentication(msg *cardv1.PlacesAuthentication) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	var dst []byte
+	dst = binary.BigEndian.AppendUint16(dst, uint16(msg.GetNewestRecordIndex()))
+
+	for i, record := range msg.GetRecords() {
+		ddRecord := &ddv1.PlaceAuthStatusRecord{}
+		ddRecord.SetEntryTime(record.GetEntryTime())
+		ddRecord.SetAuthenticationStatus(record.GetAuthenticationStatus())
+
+		b, err := opts.MarshalPlaceAuthStatusRecord(ddRecord)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal place auth status record %d: %w", i, err)
+		}
+		dst = append(dst, b...)
+	}
+
+	return dst, nil
 }

--- a/internal/card/places_authentication_test.go
+++ b/internal/card/places_authentication_test.go
@@ -1,0 +1,150 @@
+package card
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	cardv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1"
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+// makePlaceAuthStatusRecord builds a 5-byte PlaceAuthStatusRecord payload.
+//
+// Layout: 4B entryTime | 1B authenticationStatus
+func makePlaceAuthStatusRecord(entryTimeSecs uint32, authStatus byte) []byte {
+	r := make([]byte, 5)
+	binary.BigEndian.PutUint32(r[0:4], entryTimeSecs)
+	r[4] = authStatus
+	return r
+}
+
+func TestUnmarshalPlacesAuthentication(t *testing.T) {
+	t.Run("empty input error", func(t *testing.T) {
+		_, err := UnmarshalOptions{}.unmarshalPlacesAuthentication([]byte{})
+		if err == nil {
+			t.Fatal("expected error for empty input, got nil")
+		}
+	})
+
+	t.Run("pointer only, zero records", func(t *testing.T) {
+		data := []byte{0x00, 0x00}
+		got, err := UnmarshalOptions{}.unmarshalPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 0 {
+			t.Errorf("NewestRecordIndex: got %d, want 0", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 0 {
+			t.Errorf("Records count: got %d, want 0", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("one record authenticated", func(t *testing.T) {
+		// authStatus byte 0x01 → AUTHENTICATED
+		rec := makePlaceAuthStatusRecord(7200, 0x01)
+		data := append([]byte{0x00, 0x00}, rec...)
+
+		got, err := UnmarshalOptions{}.unmarshalPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.GetRecords()) != 1 {
+			t.Fatalf("Records count: got %d, want 1", len(got.GetRecords()))
+		}
+		r := got.GetRecords()[0]
+		if r.GetEntryTime().GetSeconds() != 7200 {
+			t.Errorf("EntryTime: got %d, want 7200", r.GetEntryTime().GetSeconds())
+		}
+		if r.GetAuthenticationStatus() != ddv1.PositionAuthenticationStatus_AUTHENTICATED {
+			t.Errorf("AuthenticationStatus: got %v, want AUTHENTICATED", r.GetAuthenticationStatus())
+		}
+	})
+
+	t.Run("multiple records", func(t *testing.T) {
+		rec1 := makePlaceAuthStatusRecord(1000, 0x01) // AUTHENTICATED
+		rec2 := makePlaceAuthStatusRecord(2000, 0x00) // NOT_AUTHENTICATED
+		rec3 := makePlaceAuthStatusRecord(3000, 0x00) // NOT_AUTHENTICATED
+		data := append([]byte{0x00, 0x02}, rec1...)
+		data = append(data, rec2...)
+		data = append(data, rec3...)
+
+		got, err := UnmarshalOptions{}.unmarshalPlacesAuthentication(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.GetNewestRecordIndex() != 2 {
+			t.Errorf("NewestRecordIndex: got %d, want 2", got.GetNewestRecordIndex())
+		}
+		if len(got.GetRecords()) != 3 {
+			t.Fatalf("Records count: got %d, want 3", len(got.GetRecords()))
+		}
+	})
+
+	t.Run("truncated record returns error", func(t *testing.T) {
+		// 2-byte pointer + 3 bytes (not a multiple of 5)
+		data := make([]byte, 5)
+		_, err := UnmarshalOptions{}.unmarshalPlacesAuthentication(data)
+		if err == nil {
+			t.Fatal("expected error for truncated record, got nil")
+		}
+	})
+}
+
+func TestPlacesAuthentication_ParseRawDriverCardFile(t *testing.T) {
+	rec := makePlaceAuthStatusRecord(3600, 0x01) // AUTHENTICATED
+	efData := append([]byte{0x00, 0x00}, rec...)
+
+	rawRec := &cardv1.RawCardFile_Record{}
+	rawRec.SetFile(cardv1.ElementaryFileType_EF_PLACES_AUTHENTICATION)
+	rawRec.SetGeneration(ddv1.Generation_GENERATION_2)
+	rawRec.SetContentType(cardv1.ContentType_DATA)
+	rawRec.SetValue(efData)
+
+	rawFile := &cardv1.RawCardFile{}
+	rawFile.SetRecords([]*cardv1.RawCardFile_Record{rawRec})
+
+	cardFile, err := ParseOptions{}.ParseRawDriverCardFile(rawFile)
+	if err != nil {
+		t.Fatalf("ParseRawDriverCardFile: %v", err)
+	}
+	pa := cardFile.GetTachographG2().GetPlacesAuthentication()
+	if pa == nil {
+		t.Fatal("PlacesAuthentication is nil — EF_PLACES_AUTHENTICATION not wired into switch")
+	}
+	if len(pa.GetRecords()) != 1 {
+		t.Fatalf("Records count: got %d, want 1", len(pa.GetRecords()))
+	}
+	if pa.GetRecords()[0].GetAuthenticationStatus() != ddv1.PositionAuthenticationStatus_AUTHENTICATED {
+		t.Errorf("AuthenticationStatus: got %v, want AUTHENTICATED", pa.GetRecords()[0].GetAuthenticationStatus())
+	}
+}
+
+func TestPlacesAuthentication_Fixtures(t *testing.T) {
+	hexdumpFiles, err := findHexdumpFiles(
+		cardv1.ElementaryFileType_EF_PLACES_AUTHENTICATION,
+		ddv1.Generation_GENERATION_2,
+		cardv1.ContentType_DATA,
+	)
+	if err != nil {
+		t.Fatalf("failed to discover hexdump files: %v", err)
+	}
+	if len(hexdumpFiles) == 0 {
+		t.Skip("no hexdump fixtures found for EF_PLACES_AUTHENTICATION GENERATION_2")
+	}
+	for _, hexdumpPath := range hexdumpFiles {
+		relPath := strings.TrimPrefix(hexdumpPath, "testdata/records/")
+		t.Run(strings.TrimSuffix(relPath, ".hexdump"), func(t *testing.T) {
+			data, err := readHexdump(hexdumpPath)
+			if err != nil {
+				t.Fatalf("failed to read hexdump: %v", err)
+			}
+			got, err := UnmarshalOptions{}.unmarshalPlacesAuthentication(data)
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			loadOrCreateGolden(t, got, goldenJSONPath(hexdumpPath))
+		})
+	}
+}

--- a/internal/card/unparse.go
+++ b/internal/card/unparse.go
@@ -452,6 +452,72 @@ func UnparseDriverCardFile(file *cardv1.DriverCardFile) (*cardv1.RawCardFile, er
 				return nil, err
 			}
 		}
+
+		// EF_BORDER_CROSSINGS (Gen2 only)
+		if borderCrossings := tachographG2.GetBorderCrossings(); borderCrossings != nil {
+			dataBytes, err := marshalOpts.MarshalCardBorderCrossings(borderCrossings)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_BORDER_CROSSINGS: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_BORDER_CROSSINGS, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		// EF_PLACES_AUTHENTICATION (Gen2 only)
+		if placesAuthentication := tachographG2.GetPlacesAuthentication(); placesAuthentication != nil {
+			dataBytes, err := marshalOpts.MarshalPlacesAuthentication(placesAuthentication)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_PLACES_AUTHENTICATION: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_PLACES_AUTHENTICATION, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		// EF_GNSS_PLACES_AUTHENTICATION (Gen2 only)
+		if gnssPlacesAuthentication := tachographG2.GetGnssPlacesAuthentication(); gnssPlacesAuthentication != nil {
+			dataBytes, err := marshalOpts.MarshalGnssPlacesAuthentication(gnssPlacesAuthentication)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_GNSS_PLACES_AUTHENTICATION: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_GNSS_PLACES_AUTHENTICATION, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		// EF_LOAD_UNLOAD_OPERATIONS (Gen2 only)
+		if loadUnloadOperations := tachographG2.GetLoadUnloadOperations(); loadUnloadOperations != nil {
+			dataBytes, err := marshalOpts.MarshalLoadUnloadOperations(loadUnloadOperations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_LOAD_UNLOAD_OPERATIONS: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_LOAD_UNLOAD_OPERATIONS, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		// EF_LOAD_TYPE_ENTRIES (Gen2 only)
+		if loadTypeEntries := tachographG2.GetLoadTypeEntries(); loadTypeEntries != nil {
+			dataBytes, err := marshalOpts.MarshalLoadTypeEntries(loadTypeEntries)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_LOAD_TYPE_ENTRIES: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_LOAD_TYPE_ENTRIES, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
+
+		// EF_COMPANY_ACTIVITY_DATA (Gen2 only)
+		if companyActivityData := tachographG2.GetCompanyActivityData(); companyActivityData != nil {
+			dataBytes, err := marshalOpts.MarshalCompanyActivityData(companyActivityData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal EF_COMPANY_ACTIVITY_DATA: %w", err)
+			}
+			if err := appendRecord(cardv1.ElementaryFileType_EF_COMPANY_ACTIVITY_DATA, ddv1.Generation_GENERATION_2, dataBytes, nil); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	rawFile := &cardv1.RawCardFile{}

--- a/internal/dd/card_border_crossing_record.go
+++ b/internal/dd/card_border_crossing_record.go
@@ -72,7 +72,9 @@ func (opts UnmarshalOptions) UnmarshalCardBorderCrossingRecord(data []byte) (*dd
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/dd/card_load_unload_record.go
+++ b/internal/dd/card_load_unload_record.go
@@ -73,7 +73,9 @@ func (opts UnmarshalOptions) UnmarshalCardLoadUnloadRecord(data []byte) (*ddv1.C
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/dd/geo_coordinates.go
+++ b/internal/dd/geo_coordinates.go
@@ -21,17 +21,26 @@ import (
 //   - Latitude (3 bytes): Signed 24-bit integer in ±DDMM.M × 10 format
 //   - Longitude (3 bytes): Signed 24-bit integer in ±DDDMM.M × 10 format
 //
-// Unknown position marker: 0x7FFFFF (8388607 decimal)
+// Returns nil when position is unavailable. The canonical sentinel is both
+// latitude and longitude equal to 0x7FFFFF (8388607). If only one field
+// carries the sentinel the data is malformed; the position is treated as
+// unavailable in that case too.
 func (opts UnmarshalOptions) UnmarshalGeoCoordinates(data []byte) (*ddv1.GeoCoordinates, error) {
 	const (
-		lenGeoCoordinates = 6 // 3 bytes latitude + 3 bytes longitude
+		lenGeoCoordinates  = 6 // 3 bytes latitude + 3 bytes longitude
+		geoSentinel       int32 = 0x7FFFFF
 	)
 	if len(data) != lenGeoCoordinates {
 		return nil, fmt.Errorf("invalid data length for GeoCoordinates: got %d, want %d", len(data), lenGeoCoordinates)
 	}
+	lat := readInt24(data[0:3])
+	lon := readInt24(data[3:6])
+	if lat == geoSentinel || lon == geoSentinel {
+		return nil, nil
+	}
 	var output ddv1.GeoCoordinates
-	output.SetLatitude(readInt24(data[0:3]))
-	output.SetLongitude(readInt24(data[3:6]))
+	output.SetLatitude(lat)
+	output.SetLongitude(lon)
 	return &output, nil
 }
 

--- a/internal/dd/geo_coordinates_test.go
+++ b/internal/dd/geo_coordinates_test.go
@@ -1,0 +1,74 @@
+package dd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	ddv1 "github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1"
+)
+
+func TestUnmarshalGeoCoordinates(t *testing.T) {
+	// Stuttgart: ~48°46.8'N, 9°18.0'E
+	// Encoded as DDMM.M×10: lat=48468 (0x00BD54), lon=9180 (0x0023DC)
+	stuttgartLat := int32(48468)
+	stuttgartLon := int32(9180)
+	wantStuttgart := &ddv1.GeoCoordinates{}
+	wantStuttgart.SetLatitude(stuttgartLat)
+	wantStuttgart.SetLongitude(stuttgartLon)
+
+	wantNullIsland := &ddv1.GeoCoordinates{}
+	wantNullIsland.SetLatitude(0)
+	wantNullIsland.SetLongitude(0)
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  *ddv1.GeoCoordinates
+	}{
+		{
+			// Sentinel: both 0x7FFFFF → position unavailable
+			name:  "both fields 0x7FFFFF returns nil",
+			input: []byte{0x7F, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF},
+			want:  nil,
+		},
+		{
+			// Null Island (0°N, 0°E) is a valid coordinate, not a sentinel
+			name:  "both fields 0x000000 is valid null island",
+			input: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			want:  wantNullIsland,
+		},
+		{
+			// Realistic coordinates: Stuttgart ~48°46.8'N 9°18.0'E
+			name:  "Stuttgart coordinates",
+			input: []byte{0x00, 0xBD, 0x54, 0x00, 0x23, 0xDC},
+			want:  wantStuttgart,
+		},
+		{
+			// Mixed sentinel (lat=0x7FFFFF, lon=0): malformed → treat as unavailable
+			name:  "lat sentinel only returns nil",
+			input: []byte{0x7F, 0xFF, 0xFF, 0x00, 0x00, 0x00},
+			want:  nil,
+		},
+		{
+			// Mixed sentinel (lat=0, lon=0x7FFFFF): malformed → treat as unavailable
+			name:  "lon sentinel only returns nil",
+			input: []byte{0x00, 0x00, 0x00, 0x7F, 0xFF, 0xFF},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := UnmarshalOptions{}
+			got, err := opts.UnmarshalGeoCoordinates(tt.input)
+			if err != nil {
+				t.Fatalf("UnmarshalGeoCoordinates() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("UnmarshalGeoCoordinates() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/dd/odometer.go
+++ b/internal/dd/odometer.go
@@ -34,16 +34,24 @@ func (opts MarshalOptions) MarshalOdometer(odometer int32) ([]byte, error) {
 //
 // Binary Layout (3 bytes):
 //   - Odometer Value (3 bytes): Big-endian unsigned integer
-func (opts UnmarshalOptions) UnmarshalOdometer(data []byte) (uint32, error) {
-	const lenOdometerShort = 3
+//
+// Returns nil when the sentinel value 0xFFFFFF is present, indicating the odometer
+// is not available. Callers must not set the proto field when nil is returned.
+func (opts UnmarshalOptions) UnmarshalOdometer(data []byte) (*int32, error) {
+	const (
+		lenOdometerShort  = 3
+		odometerSentinel  = 0xFFFFFF
+	)
 
 	if len(data) != lenOdometerShort {
-		return 0, fmt.Errorf("invalid data length for OdometerShort: got %d, want %d", len(data), lenOdometerShort)
+		return nil, fmt.Errorf("invalid data length for OdometerShort: got %d, want %d", len(data), lenOdometerShort)
 	}
 
-	// Convert 3-byte big-endian to uint32
-	value := uint32(data[0])<<16 | uint32(data[1])<<8 | uint32(data[2])
-	return value, nil
+	value := int32(data[0])<<16 | int32(data[1])<<8 | int32(data[2])
+	if value == odometerSentinel {
+		return nil, nil
+	}
+	return &value, nil
 }
 
 // AnonymizeOdometerValue anonymizes odometer values based on options.

--- a/internal/dd/odometer_test.go
+++ b/internal/dd/odometer_test.go
@@ -6,44 +6,56 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func ptr32(v int32) *int32 { return &v }
+
 func TestUnmarshalOdometer(t *testing.T) {
 	tests := []struct {
 		name       string
 		input      []byte
-		want       uint32
+		want       *int32
 		wantErr    bool
 		errMessage string
 	}{
+		// Sentinel: 0xFFFFFF → nil (odometer not available)
 		{
-			name:  "maximum value 999999",
-			input: []byte{0x0F, 0x42, 0x3F},
-			want:  999999,
+			name:  "sentinel 0xFFFFFF returns nil",
+			input: []byte{0xFF, 0xFF, 0xFF},
+			want:  nil,
 		},
+		// Zero is a valid odometer value, not a sentinel
 		{
-			name:  "zero value",
+			name:  "zero value is valid",
 			input: []byte{0x00, 0x00, 0x00},
-			want:  0,
+			want:  ptr32(0),
+		},
+		// Value just below the sentinel is valid
+		{
+			name:  "0xFFFFFE is valid (16777214)",
+			input: []byte{0xFF, 0xFF, 0xFE},
+			want:  ptr32(16777214),
+		},
+		// Normal values
+		{
+			name:  "maximum spec value 999999",
+			input: []byte{0x0F, 0x42, 0x3F},
+			want:  ptr32(999999),
 		},
 		{
 			name:  "middle value 123456",
 			input: []byte{0x01, 0xE2, 0x40},
-			want:  123456,
+			want:  ptr32(123456),
+		},
+		{
+			name:  "value 375000 (0x05B8D8)",
+			input: []byte{0x05, 0xB8, 0xD8},
+			want:  ptr32(375000),
 		},
 		{
 			name:  "value 1",
 			input: []byte{0x00, 0x00, 0x01},
-			want:  1,
+			want:  ptr32(1),
 		},
-		{
-			name:  "value 255",
-			input: []byte{0x00, 0x00, 0xFF},
-			want:  255,
-		},
-		{
-			name:  "value 65535",
-			input: []byte{0x00, 0xFF, 0xFF},
-			want:  65535,
-		},
+		// Error cases
 		{
 			name:       "buffer larger than needed - exact length required",
 			input:      []byte{0x01, 0xE2, 0x40, 0xFF, 0xFF},
@@ -53,12 +65,6 @@ func TestUnmarshalOdometer(t *testing.T) {
 		{
 			name:       "insufficient data - 2 bytes",
 			input:      []byte{0x01, 0x02},
-			wantErr:    true,
-			errMessage: "invalid data length for OdometerShort",
-		},
-		{
-			name:       "insufficient data - 1 byte",
-			input:      []byte{0x01},
 			wantErr:    true,
 			errMessage: "invalid data length for OdometerShort",
 		},
@@ -83,8 +89,8 @@ func TestUnmarshalOdometer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("UnmarshalOdometer() unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("UnmarshalOdometer() = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("UnmarshalOdometer() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -93,7 +99,7 @@ func TestUnmarshalOdometer(t *testing.T) {
 func TestAppendOdometer(t *testing.T) {
 	tests := []struct {
 		name  string
-		input uint32
+		input int32
 		want  []byte
 	}{
 		{
@@ -131,7 +137,7 @@ func TestAppendOdometer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := MarshalOptions{}
-			got, err := opts.MarshalOdometer(int32(tt.input))
+			got, err := opts.MarshalOdometer(tt.input)
 			if err != nil {
 				t.Fatalf("MarshalOdometer() unexpected error: %v", err)
 			}
@@ -167,21 +173,21 @@ func TestOdometerRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Unmarshal
 			unmarshalOpts := UnmarshalOptions{}
-			opts := MarshalOptions{}
+			marshalOpts := MarshalOptions{}
 			odometer, err := unmarshalOpts.UnmarshalOdometer(tt.input)
 			if err != nil {
 				t.Fatalf("UnmarshalOdometer() unexpected error: %v", err)
 			}
+			if odometer == nil {
+				t.Fatal("UnmarshalOdometer() returned nil for non-sentinel value")
+			}
 
-			// Marshal
-			got, err := opts.MarshalOdometer(int32(odometer))
+			got, err := marshalOpts.MarshalOdometer(*odometer)
 			if err != nil {
 				t.Fatalf("MarshalOdometer() unexpected error: %v", err)
 			}
 
-			// Verify round-trip
 			if diff := cmp.Diff(tt.input, got); diff != "" {
 				t.Errorf("Round-trip mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/dd/place_auth_record.go
+++ b/internal/dd/place_auth_record.go
@@ -88,7 +88,9 @@ func (opts UnmarshalOptions) UnmarshalPlaceAuthRecord(data []byte) (*ddv1.PlaceA
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	// entryGNSSPlaceAuthRecord (12 bytes)
 	entryGNSSPlaceAuthRecord, err := opts.UnmarshalGNSSPlaceAuthRecord(data[idxEntryGNSSPlaceAuthRecord : idxEntryGNSSPlaceAuthRecord+lenGNSSPlaceAuthRecord])

--- a/internal/dd/vu_border_crossing_record.go
+++ b/internal/dd/vu_border_crossing_record.go
@@ -93,7 +93,9 @@ func (opts UnmarshalOptions) UnmarshalVuBorderCrossingRecord(data []byte) (*ddv1
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/dd/vu_card_iw_record.go
+++ b/internal/dd/vu_card_iw_record.go
@@ -102,7 +102,9 @@ func (opts UnmarshalOptions) UnmarshalVuCardIWRecord(data []byte) (*ddv1.VuCardI
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal odometer at insertion: %w", err)
 	}
-	record.SetOdometerAtInsertionKm(int32(odometerAtInsertion))
+	if odometerAtInsertion != nil {
+		record.SetOdometerAtInsertionKm(*odometerAtInsertion)
+	}
 
 	// cardSlotNumber (1 byte)
 	cardSlotNumber, err := UnmarshalEnum[ddv1.CardSlotNumber](data[idxCardSlotNumber])
@@ -123,7 +125,9 @@ func (opts UnmarshalOptions) UnmarshalVuCardIWRecord(data []byte) (*ddv1.VuCardI
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal odometer at withdrawal: %w", err)
 	}
-	record.SetOdometerAtWithdrawalKm(int32(odometerAtWithdrawal))
+	if odometerAtWithdrawal != nil {
+		record.SetOdometerAtWithdrawalKm(*odometerAtWithdrawal)
+	}
 
 	// previousVehicleInfo (19 bytes)
 	previousVehicleInfo, err := opts.UnmarshalPreviousVehicleInfo(data[idxPreviousVehicleInfo : idxPreviousVehicleInfo+lenPreviousVehicleInfo])

--- a/internal/dd/vu_card_iw_record_g2.go
+++ b/internal/dd/vu_card_iw_record_g2.go
@@ -102,7 +102,9 @@ func (opts UnmarshalOptions) UnmarshalVuCardIWRecordG2(data []byte) (*ddv1.VuCar
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal odometer at insertion: %w", err)
 	}
-	record.SetOdometerAtInsertionKm(int32(odometerAtInsertion))
+	if odometerAtInsertion != nil {
+		record.SetOdometerAtInsertionKm(*odometerAtInsertion)
+	}
 
 	// cardSlotNumber (1 byte)
 	cardSlotNumber, err := UnmarshalEnum[ddv1.CardSlotNumber](data[idxCardSlotNumber])
@@ -123,7 +125,9 @@ func (opts UnmarshalOptions) UnmarshalVuCardIWRecordG2(data []byte) (*ddv1.VuCar
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal odometer at withdrawal: %w", err)
 	}
-	record.SetOdometerAtWithdrawalKm(int32(odometerAtWithdrawal))
+	if odometerAtWithdrawal != nil {
+		record.SetOdometerAtWithdrawalKm(*odometerAtWithdrawal)
+	}
 
 	// previousVehicleInfo (20 bytes)
 	previousVehicleInfo, err := opts.UnmarshalPreviousVehicleInfoG2(data[idxPreviousVehicleInfo : idxPreviousVehicleInfo+lenPreviousVehicleInfoG2])

--- a/internal/dd/vu_gnss_ad_record.go
+++ b/internal/dd/vu_gnss_ad_record.go
@@ -83,7 +83,9 @@ func (opts UnmarshalOptions) UnmarshalVuGNSSADRecord(data []byte) (*ddv1.VuGNSSA
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/dd/vu_gnss_ad_record_g2.go
+++ b/internal/dd/vu_gnss_ad_record_g2.go
@@ -83,7 +83,9 @@ func (opts UnmarshalOptions) UnmarshalVuGNSSADRecordG2(data []byte) (*ddv1.VuGNS
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/dd/vu_load_unload_record.go
+++ b/internal/dd/vu_load_unload_record.go
@@ -94,7 +94,9 @@ func (opts UnmarshalOptions) UnmarshalVuLoadUnloadRecord(data []byte) (*ddv1.VuL
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal vehicle odometer value: %w", err)
 	}
-	record.SetVehicleOdometerKm(int32(vehicleOdometerValue))
+	if vehicleOdometerValue != nil {
+		record.SetVehicleOdometerKm(*vehicleOdometerValue)
+	}
 
 	return record, nil
 }

--- a/internal/vu/activities_gen1.go
+++ b/internal/vu/activities_gen1.go
@@ -91,7 +91,9 @@ func unmarshalActivitiesGen1(value []byte) (*vuv1.ActivitiesGen1, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal OdometerValueMidnight: %w", err)
 	}
-	activities.SetOdometerMidnightKm(int32(odometer))
+	if odometer != nil {
+		activities.SetOdometerMidnightKm(*odometer)
+	}
 	offset += 3
 
 	// VuCardIWData: 2 bytes (noOfIWRecords) + (noOfIWRecords * 129 bytes)

--- a/internal/vu/activities_gen2_v1.go
+++ b/internal/vu/activities_gen2_v1.go
@@ -68,7 +68,9 @@ func unmarshalActivitiesGen2V1(value []byte) (*vuv1.ActivitiesGen2V1, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse OdometerValueMidnightRecordArray: %w", err)
 	}
-	activities.SetOdometerMidnightKm(odometerMidnightKm)
+	if odometerMidnightKm != nil {
+		activities.SetOdometerMidnightKm(*odometerMidnightKm)
+	}
 	offset += bytesRead
 
 	// VuCardIWRecordArray (Gen2 - 132 bytes per record)
@@ -252,29 +254,30 @@ func parseTimeRealRecordArray(data []byte, offset int) (*timestamppb.Timestamp, 
 }
 
 // parseOdometerValueMidnightRecordArray parses an OdometerValueMidnightRecordArray (should have 1 record of 3 bytes).
-func parseOdometerValueMidnightRecordArray(data []byte, offset int) (int32, int, error) {
+// Returns nil when the odometer sentinel 0xFFFFFF is present.
+func parseOdometerValueMidnightRecordArray(data []byte, offset int) (*int32, int, error) {
 	_, recordSize, noOfRecords, headerSize, err := parseRecordArrayHeader(data, offset)
 	if err != nil {
-		return 0, 0, err
+		return nil, 0, err
 	}
 
 	if noOfRecords != 1 {
-		return 0, 0, fmt.Errorf("expected 1 OdometerValueMidnight record, got %d", noOfRecords)
+		return nil, 0, fmt.Errorf("expected 1 OdometerValueMidnight record, got %d", noOfRecords)
 	}
 
 	if recordSize != 3 {
-		return 0, 0, fmt.Errorf("expected OdometerValueMidnight record size 3, got %d", recordSize)
+		return nil, 0, fmt.Errorf("expected OdometerValueMidnight record size 3, got %d", recordSize)
 	}
 
 	recordStart := offset + headerSize
 	var opts dd.UnmarshalOptions
 	odometer, err := opts.UnmarshalOdometer(data[recordStart : recordStart+int(recordSize)])
 	if err != nil {
-		return 0, 0, fmt.Errorf("unmarshal Odometer: %w", err)
+		return nil, 0, fmt.Errorf("unmarshal Odometer: %w", err)
 	}
 
 	totalSize := headerSize + int(recordSize)*int(noOfRecords)
-	return int32(odometer), totalSize, nil
+	return odometer, totalSize, nil
 }
 
 // parseVuCardIWRecordArrayG2 parses a VuCardIWRecordArray (Gen2 - 132 bytes per record).

--- a/internal/vu/activities_gen2_v2.go
+++ b/internal/vu/activities_gen2_v2.go
@@ -66,7 +66,9 @@ func unmarshalActivitiesGen2V2(value []byte) (*vuv1.ActivitiesGen2V2, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse OdometerValueMidnightRecordArray: %w", err)
 	}
-	activities.SetOdometerMidnightKm(odometerMidnightKm)
+	if odometerMidnightKm != nil {
+		activities.SetOdometerMidnightKm(*odometerMidnightKm)
+	}
 	offset += bytesRead
 
 	// VuCardIWRecordArray (Gen2 - 132 bytes per record, same as V1)


### PR DESCRIPTION
## What

Six Gen2-exclusive Elementary Files were parsed but not wired into the marshal/unparse/anonymize pipelines, so they were silently dropped on a parse → unparse → marshal round-trip.

Wired into `UnparseDriverCardFile`:
- `EF_BORDER_CROSSINGS`
- `EF_PLACES_AUTHENTICATION`
- `EF_GNSS_PLACES_AUTHENTICATION`
- `EF_LOAD_UNLOAD_OPERATIONS`
- `EF_LOAD_TYPE_ENTRIES`
- `EF_COMPANY_ACTIVITY_DATA`

### Anonymization

- **CompanyActivityData**
  - Replaces `FullCardNumberAndGeneration` and `VehicleRegistrationIdentification` with deterministic test values
  - Zeros timestamps

- **PlacesAuthentication, GnssPlacesAuthentication, LoadTypeEntries, LoadUnloadOperations**
  - Zeros entry/activity timestamps (correlatable with real-world driving events)
  - Non-PII fields preserved

### Sentinel normalization (dd)

- `GeoCoordinates` `0x7FFFFF` → `nil` (spec-defined "unknown position")
- `OdometerShort` `0xFFFFFF` → `nil` (spec-defined "not available")

## Why

Without unparse wiring, these EFs were lost in any write-back flow. Without anonymization, timestamped records would survive the anonymization pass and could correlate with real driver activity.