### PR TITLE
fix(proto): add debug_redact to PII fields

### DIFF
--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/company_card_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/company_card_identification.pb.go
@@ -477,16 +477,16 @@ var File_wayplatform_connect_tachograph_card_v1_company_card_identification_prot
 
 const file_wayplatform_connect_tachograph_card_v1_company_card_identification_proto_rawDesc = "" +
 	"\n" +
-	"Hwayplatform/connect/tachograph/card/v1/company_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xf0\a\n" +
+	"Hwayplatform/connect/tachograph/card/v1/company_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xfa\a\n" +
 	"\x19CompanyCardIdentification\x12n\n" +
-	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12l\n" +
-	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationR\x13ownerIdentification\x12p\n" +
+	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12q\n" +
+	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationB\x03\x80\x01\x01R\x13ownerIdentification\x12p\n" +
 	"\x1bcard_issuing_authority_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x18cardIssuingAuthorityName\x12B\n" +
 	"\x0fcard_issue_date\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rcardIssueDate\x12J\n" +
 	"\x13card_validity_begin\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x11cardValidityBegin\x12D\n" +
 	"\x10card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0ecardExpiryDate\x12T\n" +
-	"\fcompany_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\vcompanyName\x12Z\n" +
-	"\x0fcompany_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0ecompanyAddress\x12y\n" +
+	"\fcompany_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\vcompanyName\x12_\n" +
+	"\x0fcompany_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x0ecompanyAddress\x12y\n" +
 	"\x1ecard_holder_preferred_language\x18\t \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bcardHolderPreferredLanguage\x12\x1c\n" +
 	"\tsignature\x18c \x01(\fR\tsignature\x12b\n" +
 	"\x0eauthentication\x18d \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xeb\x02\n" +

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/control_card_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/control_card_identification.pb.go
@@ -540,19 +540,19 @@ var File_wayplatform_connect_tachograph_card_v1_control_card_identification_prot
 
 const file_wayplatform_connect_tachograph_card_v1_control_card_identification_proto_rawDesc = "" +
 	"\n" +
-	"Hwayplatform/connect/tachograph/card/v1/control_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xcf\t\n" +
+	"Hwayplatform/connect/tachograph/card/v1/control_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xe3\t\n" +
 	"\x19ControlCardIdentification\x12n\n" +
-	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12l\n" +
-	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationR\x13ownerIdentification\x12p\n" +
+	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12q\n" +
+	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationB\x03\x80\x01\x01R\x13ownerIdentification\x12p\n" +
 	"\x1bcard_issuing_authority_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x18cardIssuingAuthorityName\x12B\n" +
 	"\x0fcard_issue_date\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rcardIssueDate\x12J\n" +
 	"\x13card_validity_begin\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x11cardValidityBegin\x12D\n" +
 	"\x10card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0ecardExpiryDate\x12]\n" +
-	"\x11control_body_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fcontrolBodyName\x12c\n" +
-	"\x14control_body_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x12controlBodyAddress\x12a\n" +
-	"\x13card_holder_surname\x18\t \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x11cardHolderSurname\x12h\n" +
+	"\x11control_body_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fcontrolBodyName\x12h\n" +
+	"\x14control_body_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x12controlBodyAddress\x12f\n" +
+	"\x13card_holder_surname\x18\t \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x11cardHolderSurname\x12m\n" +
 	"\x17card_holder_first_names\x18\n" +
-	" \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x14cardHolderFirstNames\x12y\n" +
+	" \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x14cardHolderFirstNames\x12y\n" +
 	"\x1ecard_holder_preferred_language\x18\v \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bcardHolderPreferredLanguage\x12\x1c\n" +
 	"\tsignature\x18c \x01(\fR\tsignature\x12b\n" +
 	"\x0eauthentication\x18d \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xeb\x02\n" +

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/driver_card_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/driver_card_identification.pb.go
@@ -505,16 +505,16 @@ var File_wayplatform_connect_tachograph_card_v1_driver_card_identification_proto
 
 const file_wayplatform_connect_tachograph_card_v1_driver_card_identification_proto_rawDesc = "" +
 	"\n" +
-	"Gwayplatform/connect/tachograph/card/v1/driver_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a/wayplatform/connect/tachograph/dd/v1/date.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xee\b\n" +
+	"Gwayplatform/connect/tachograph/card/v1/driver_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a/wayplatform/connect/tachograph/dd/v1/date.proto\x1a@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xfd\b\n" +
 	"\x18DriverCardIdentification\x12n\n" +
-	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12o\n" +
-	"\x15driver_identification\x18\x02 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.DriverIdentificationR\x14driverIdentification\x12p\n" +
+	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12t\n" +
+	"\x15driver_identification\x18\x02 \x01(\v2:.wayplatform.connect.tachograph.dd.v1.DriverIdentificationB\x03\x80\x01\x01R\x14driverIdentification\x12p\n" +
 	"\x1bcard_issuing_authority_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x18cardIssuingAuthorityName\x12B\n" +
 	"\x0fcard_issue_date\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rcardIssueDate\x12J\n" +
 	"\x13card_validity_begin\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x11cardValidityBegin\x12D\n" +
-	"\x10card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0ecardExpiryDate\x12a\n" +
-	"\x13card_holder_surname\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x11cardHolderSurname\x12h\n" +
-	"\x17card_holder_first_names\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x14cardHolderFirstNames\x12_\n" +
+	"\x10card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0ecardExpiryDate\x12f\n" +
+	"\x13card_holder_surname\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x11cardHolderSurname\x12m\n" +
+	"\x17card_holder_first_names\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x14cardHolderFirstNames\x12_\n" +
 	"\x16card_holder_birth_date\x18\t \x01(\v2*.wayplatform.connect.tachograph.dd.v1.DateR\x13cardHolderBirthDate\x12y\n" +
 	"\x1ecard_holder_preferred_language\x18\n" +
 	" \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bcardHolderPreferredLanguage\x12\x1c\n" +

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/driving_licence_info.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/driving_licence_info.pb.go
@@ -268,11 +268,11 @@ var File_wayplatform_connect_tachograph_card_v1_driving_licence_info_proto proto
 
 const file_wayplatform_connect_tachograph_card_v1_driving_licence_info_proto_rawDesc = "" +
 	"\n" +
-	"Awayplatform/connect/tachograph/card/v1/driving_licence_info.proto\x12&wayplatform.connect.tachograph.card.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xfa\x03\n" +
+	"Awayplatform/connect/tachograph/card/v1/driving_licence_info.proto\x12&wayplatform.connect.tachograph.card.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xff\x03\n" +
 	"\x12DrivingLicenceInfo\x12|\n" +
 	"!driving_licence_issuing_authority\x18\x01 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x1edrivingLicenceIssuingAuthority\x12x\n" +
-	"\x1edriving_licence_issuing_nation\x18\x02 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x1bdrivingLicenceIssuingNation\x12j\n" +
-	"\x16driving_licence_number\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x14drivingLicenceNumber\x12\x1c\n" +
+	"\x1edriving_licence_issuing_nation\x18\x02 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x1bdrivingLicenceIssuingNation\x12o\n" +
+	"\x16driving_licence_number\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueB\x03\x80\x01\x01R\x14drivingLicenceNumber\x12\x1c\n" +
 	"\tsignature\x18\x04 \x01(\fR\tsignature\x12b\n" +
 	"\x0eauthentication\x18c \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xe4\x02\n" +
 	"*com.wayplatform.connect.tachograph.card.v1B\x17DrivingLicenceInfoProtoP\x01Z`github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/card/v1;cardv1\xa2\x02\x04WCTC\xaa\x02&Wayplatform.Connect.Tachograph.Card.V1\xca\x02&Wayplatform\\Connect\\Tachograph\\Card\\V1\xe2\x022Wayplatform\\Connect\\Tachograph\\Card\\V1\\GPBMetadata\xea\x02*Wayplatform::Connect::Tachograph::Card::V1b\beditionsp\xe8\a"

--- a/proto/gen/go/wayplatform/connect/tachograph/card/v1/workshop_card_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/card/v1/workshop_card_identification.pb.go
@@ -540,19 +540,19 @@ var File_wayplatform_connect_tachograph_card_v1_workshop_card_identification_pro
 
 const file_wayplatform_connect_tachograph_card_v1_workshop_card_identification_proto_rawDesc = "" +
 	"\n" +
-	"Iwayplatform/connect/tachograph/card/v1/workshop_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xc2\t\n" +
+	"Iwayplatform/connect/tachograph/card/v1/workshop_card_identification.proto\x12&wayplatform.connect.tachograph.card.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\x1a9wayplatform/connect/tachograph/dd/v1/nation_numeric.proto\x1a?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\x1a?wayplatform/connect/tachograph/security/v1/authentication.proto\"\xd6\t\n" +
 	"\x1aWorkshopCardIdentification\x12n\n" +
-	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12l\n" +
-	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationR\x13ownerIdentification\x12p\n" +
+	"\x19card_issuing_member_state\x18\x01 \x01(\x0e23.wayplatform.connect.tachograph.dd.v1.NationNumericR\x16cardIssuingMemberState\x12q\n" +
+	"\x14owner_identification\x18\x02 \x01(\v29.wayplatform.connect.tachograph.dd.v1.OwnerIdentificationB\x03\x80\x01\x01R\x13ownerIdentification\x12p\n" +
 	"\x1bcard_issuing_authority_name\x18\x03 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x18cardIssuingAuthorityName\x12B\n" +
 	"\x0fcard_issue_date\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rcardIssueDate\x12J\n" +
 	"\x13card_validity_begin\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x11cardValidityBegin\x12D\n" +
 	"\x10card_expiry_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0ecardExpiryDate\x12V\n" +
-	"\rworkshop_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\fworkshopName\x12\\\n" +
-	"\x10workshop_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x0fworkshopAddress\x12a\n" +
-	"\x13card_holder_surname\x18\t \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x11cardHolderSurname\x12h\n" +
+	"\rworkshop_name\x18\a \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\fworkshopName\x12a\n" +
+	"\x10workshop_address\x18\b \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x0fworkshopAddress\x12f\n" +
+	"\x13card_holder_surname\x18\t \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x11cardHolderSurname\x12m\n" +
 	"\x17card_holder_first_names\x18\n" +
-	" \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x14cardHolderFirstNames\x12y\n" +
+	" \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x14cardHolderFirstNames\x12y\n" +
 	"\x1ecard_holder_preferred_language\x18\v \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1bcardHolderPreferredLanguage\x12\x1c\n" +
 	"\tsignature\x18c \x01(\fR\tsignature\x12b\n" +
 	"\x0eauthentication\x18d \x01(\v2:.wayplatform.connect.tachograph.security.v1.AuthenticationR\x0eauthenticationB\xec\x02\n" +

--- a/proto/gen/go/wayplatform/connect/tachograph/dd/v1/driver_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/dd/v1/driver_identification.pb.go
@@ -165,11 +165,11 @@ var File_wayplatform_connect_tachograph_dd_v1_driver_identification_proto protor
 
 const file_wayplatform_connect_tachograph_dd_v1_driver_identification_proto_rawDesc = "" +
 	"\n" +
-	"@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\"\xde\x02\n" +
-	"\x14DriverIdentification\x12v\n" +
-	"\x1cdriver_identification_number\x18\x01 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x1adriverIdentificationNumber\x12j\n" +
-	"\x16card_replacement_index\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x14cardReplacementIndex\x12b\n" +
-	"\x12card_renewal_index\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x10cardRenewalIndexB\xd8\x02\n" +
+	"@wayplatform/connect/tachograph/dd/v1/driver_identification.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\"\xed\x02\n" +
+	"\x14DriverIdentification\x12{\n" +
+	"\x1cdriver_identification_number\x18\x01 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueB\x03\x80\x01\x01R\x1adriverIdentificationNumber\x12o\n" +
+	"\x16card_replacement_index\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueB\x03\x80\x01\x01R\x14cardReplacementIndex\x12g\n" +
+	"\x12card_renewal_index\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueB\x03\x80\x01\x01R\x10cardRenewalIndexB\xd8\x02\n" +
 	"(com.wayplatform.connect.tachograph.dd.v1B\x19DriverIdentificationProtoP\x01Z\\github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1;ddv1\xa2\x02\x04WCTD\xaa\x02$Wayplatform.Connect.Tachograph.Dd.V1\xca\x02$Wayplatform\\Connect\\Tachograph\\Dd\\V1\xe2\x020Wayplatform\\Connect\\Tachograph\\Dd\\V1\\GPBMetadata\xea\x02(Wayplatform::Connect::Tachograph::Dd::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_dd_v1_driver_identification_proto_msgTypes = make([]protoimpl.MessageInfo, 1)

--- a/proto/gen/go/wayplatform/connect/tachograph/dd/v1/holder_name.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/dd/v1/holder_name.pb.go
@@ -147,11 +147,11 @@ var File_wayplatform_connect_tachograph_dd_v1_holder_name_proto protoreflect.Fil
 
 const file_wayplatform_connect_tachograph_dd_v1_holder_name_proto_rawDesc = "" +
 	"\n" +
-	"6wayplatform/connect/tachograph/dd/v1/holder_name.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\"\xc7\x01\n" +
+	"6wayplatform/connect/tachograph/dd/v1/holder_name.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a7wayplatform/connect/tachograph/dd/v1/string_value.proto\"\xd1\x01\n" +
 	"\n" +
-	"HolderName\x12X\n" +
-	"\x0eholder_surname\x18\x01 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\rholderSurname\x12_\n" +
-	"\x12holder_first_names\x18\x02 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueR\x10holderFirstNamesB\xce\x02\n" +
+	"HolderName\x12]\n" +
+	"\x0eholder_surname\x18\x01 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\rholderSurname\x12d\n" +
+	"\x12holder_first_names\x18\x02 \x01(\v21.wayplatform.connect.tachograph.dd.v1.StringValueB\x03\x80\x01\x01R\x10holderFirstNamesB\xce\x02\n" +
 	"(com.wayplatform.connect.tachograph.dd.v1B\x0fHolderNameProtoP\x01Z\\github.com/way-platform/tachograph-go/proto/gen/go/wayplatform/connect/tachograph/dd/v1;ddv1\xa2\x02\x04WCTD\xaa\x02$Wayplatform.Connect.Tachograph.Dd.V1\xca\x02$Wayplatform\\Connect\\Tachograph\\Dd\\V1\xe2\x020Wayplatform\\Connect\\Tachograph\\Dd\\V1\\GPBMetadata\xea\x02(Wayplatform::Connect::Tachograph::Dd::V1b\beditionsp\xe8\a"
 
 var file_wayplatform_connect_tachograph_dd_v1_holder_name_proto_msgTypes = make([]protoimpl.MessageInfo, 1)

--- a/proto/gen/go/wayplatform/connect/tachograph/dd/v1/owner_identification.pb.go
+++ b/proto/gen/go/wayplatform/connect/tachograph/dd/v1/owner_identification.pb.go
@@ -212,9 +212,9 @@ var File_wayplatform_connect_tachograph_dd_v1_owner_identification_proto protore
 
 const file_wayplatform_connect_tachograph_dd_v1_owner_identification_proto_rawDesc = "" +
 	"\n" +
-	"?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\"\x9f\x03\n" +
-	"\x13OwnerIdentification\x12g\n" +
-	"\x14owner_identification\x18\x01 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x13ownerIdentification\x12a\n" +
+	"?wayplatform/connect/tachograph/dd/v1/owner_identification.proto\x12$wayplatform.connect.tachograph.dd.v1\x1a;wayplatform/connect/tachograph/dd/v1/ia5_string_value.proto\"\xa4\x03\n" +
+	"\x13OwnerIdentification\x12l\n" +
+	"\x14owner_identification\x18\x01 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueB\x03\x80\x01\x01R\x13ownerIdentification\x12a\n" +
 	"\x11consecutive_index\x18\x02 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x10consecutiveIndex\x12a\n" +
 	"\x11replacement_index\x18\x03 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\x10replacementIndex\x12Y\n" +
 	"\rrenewal_index\x18\x04 \x01(\v24.wayplatform.connect.tachograph.dd.v1.Ia5StringValueR\frenewalIndexB\xd7\x02\n" +

--- a/proto/wayplatform/connect/tachograph/card/v1/company_card_identification.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/company_card_identification.proto
@@ -71,7 +71,7 @@ message CompanyCardIdentification {
   //     cardRenewalIndex CardRenewalIndex
   // }
   // Binary size: 16 bytes (13 + 1 + 1 + 1 bytes)
-  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2;
+  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2 [debug_redact = true];
 
   // The name of the authority that issued the card.
   //
@@ -113,7 +113,7 @@ message CompanyCardIdentification {
   // See Data Dictionary, Section 2.49, `companyAddress`.
   // ASN.1 Specification: Address ::= SEQUENCE { codePage INTEGER(0..255), address OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue company_address = 8;
+  wayplatform.connect.tachograph.dd.v1.StringValue company_address = 8 [debug_redact = true];
 
   // The preferred language of the card holder.
   //

--- a/proto/wayplatform/connect/tachograph/card/v1/control_card_identification.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/control_card_identification.proto
@@ -74,7 +74,7 @@ message ControlCardIdentification {
   //     cardRenewalIndex CardRenewalIndex
   // }
   // Binary size: 16 bytes (13 + 1 + 1 + 1 bytes)
-  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2;
+  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2 [debug_redact = true];
 
   // The name of the authority that issued the card.
   //
@@ -116,21 +116,21 @@ message ControlCardIdentification {
   // See Data Dictionary, Section 2.52, `controlBodyAddress`.
   // ASN.1 Specification: Address ::= SEQUENCE { codePage INTEGER(0..255), address OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue control_body_address = 8;
+  wayplatform.connect.tachograph.dd.v1.StringValue control_body_address = 8 [debug_redact = true];
 
   // The surname of the card holder.
   //
   // Corresponds to `holderSurname` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 9;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 9 [debug_redact = true];
 
   // The first name(s) of the card holder.
   //
   // Corresponds to `holderFirstNames` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 10;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 10 [debug_redact = true];
 
   // The preferred language of the card holder.
   //

--- a/proto/wayplatform/connect/tachograph/card/v1/driver_card_identification.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/driver_card_identification.proto
@@ -70,7 +70,7 @@ message DriverCardIdentification {
   //     driverIdentificationNumber IA5String(SIZE(14))
   // }
   // Binary size: 14 bytes (IA5String)
-  wayplatform.connect.tachograph.dd.v1.DriverIdentification driver_identification = 2;
+  wayplatform.connect.tachograph.dd.v1.DriverIdentification driver_identification = 2 [debug_redact = true];
 
   // The name of the authority that issued the card.
   //
@@ -105,14 +105,14 @@ message DriverCardIdentification {
   // Corresponds to `holderSurname` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 7;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 7 [debug_redact = true];
 
   // The first name(s) of the card holder.
   //
   // Corresponds to `holderFirstNames` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 8;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 8 [debug_redact = true];
 
   // The birth date of the card holder.
   //

--- a/proto/wayplatform/connect/tachograph/card/v1/driving_licence_info.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/driving_licence_info.proto
@@ -50,7 +50,7 @@ message DrivingLicenceInfo {
   // ASN.1 Specification:
   //
   //     IA5String(SIZE(16))
-  wayplatform.connect.tachograph.dd.v1.Ia5StringValue driving_licence_number = 3;
+  wayplatform.connect.tachograph.dd.v1.Ia5StringValue driving_licence_number = 3 [debug_redact = true];
 
   // Signature data from the following file block, if tagged as a signature for
   // this EF according to the card file format specification (Appendix 2).

--- a/proto/wayplatform/connect/tachograph/card/v1/workshop_card_identification.proto
+++ b/proto/wayplatform/connect/tachograph/card/v1/workshop_card_identification.proto
@@ -74,7 +74,7 @@ message WorkshopCardIdentification {
   //     cardRenewalIndex CardRenewalIndex
   // }
   // Binary size: 16 bytes (13 + 1 + 1 + 1 bytes)
-  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2;
+  wayplatform.connect.tachograph.dd.v1.OwnerIdentification owner_identification = 2 [debug_redact = true];
 
   // The name of the authority that issued the card.
   //
@@ -116,21 +116,21 @@ message WorkshopCardIdentification {
   // See Data Dictionary, Section 2.237, `workshopAddress`.
   // ASN.1 Specification: Address ::= SEQUENCE { codePage INTEGER(0..255), address OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue workshop_address = 8;
+  wayplatform.connect.tachograph.dd.v1.StringValue workshop_address = 8 [debug_redact = true];
 
   // The surname of the card holder.
   //
   // Corresponds to `holderSurname` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 9;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_surname = 9 [debug_redact = true];
 
   // The first name(s) of the card holder.
   //
   // Corresponds to `holderFirstNames` within `HolderName` (Data Dictionary Section 2.83).
   // ASN.1 Specification: Name ::= SEQUENCE { codePage INTEGER(0..255), name OCTET STRING (SIZE(35)) }
   // Binary size: 36 bytes (1 byte code page + 35 bytes string data)
-  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 10;
+  wayplatform.connect.tachograph.dd.v1.StringValue card_holder_first_names = 10 [debug_redact = true];
 
   // The preferred language of the card holder.
   //

--- a/proto/wayplatform/connect/tachograph/dd/v1/driver_identification.proto
+++ b/proto/wayplatform/connect/tachograph/dd/v1/driver_identification.proto
@@ -20,17 +20,17 @@ message DriverIdentification {
   // The core driver identification number string.
   //
   // Corresponds to `driverIdentificationNumber`.
-  Ia5StringValue driver_identification_number = 1;
+  Ia5StringValue driver_identification_number = 1 [debug_redact = true];
 
   // The card replacement index.
   //
   // Corresponds to `cardReplacementIndex`.
   // See Data Dictionary, Section 2.31.
-  Ia5StringValue card_replacement_index = 2;
+  Ia5StringValue card_replacement_index = 2 [debug_redact = true];
 
   // The card renewal index.
   //
   // Corresponds to `cardRenewalIndex`.
   // See Data Dictionary, Section 2.30.
-  Ia5StringValue card_renewal_index = 3;
+  Ia5StringValue card_renewal_index = 3 [debug_redact = true];
 }

--- a/proto/wayplatform/connect/tachograph/dd/v1/holder_name.proto
+++ b/proto/wayplatform/connect/tachograph/dd/v1/holder_name.proto
@@ -25,7 +25,7 @@ message HolderName {
   //         codePage INTEGER,
   //         name OCTET STRING
   //     }
-  StringValue holder_surname = 1;
+  StringValue holder_surname = 1 [debug_redact = true];
 
   // The first name(s) and initials of the holder.
   //
@@ -37,5 +37,5 @@ message HolderName {
   //         codePage INTEGER,
   //         name OCTET STRING
   //     }
-  StringValue holder_first_names = 2;
+  StringValue holder_first_names = 2 [debug_redact = true];
 }

--- a/proto/wayplatform/connect/tachograph/dd/v1/owner_identification.proto
+++ b/proto/wayplatform/connect/tachograph/dd/v1/owner_identification.proto
@@ -29,7 +29,7 @@ message OwnerIdentification {
   // ASN.1 Definition:
   //
   //     ownerIdentification IA5String(SIZE(13))
-  Ia5StringValue owner_identification = 1;
+  Ia5StringValue owner_identification = 1 [debug_redact = true];
 
   // A single-digit index for the card.
   //


### PR DESCRIPTION
## Summary

- Add `debug_redact = true` to card holder names (`holder_surname`, `holder_first_names`, `card_holder_surname`, `card_holder_first_names`)
- Add `debug_redact = true` to card identification numbers (`driver_identification_number`, `card_replacement_index`, `card_renewal_index`, `owner_identification`)
- Add `debug_redact = true` to addresses (`control_body_address`, `company_address`, `workshop_address`)
- Add `debug_redact = true` to `driving_licence_number`
- Add `debug_redact = true` to parent message fields that transitively contain PII (`driver_identification`, `owner_identification`)

## Context

Prevents personal data (names, card IDs, addresses, licence numbers) from appearing in proto debug/text format output (logs, traces). Aligns with the `debug_redact` rollout across the Way Platform monorepo (way-platform/main#4301).

## Test plan

- [x] `mise run build` passes locally
- [ ] CI green